### PR TITLE
run test, e2e tests and prod build in parallel

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -23,10 +23,11 @@
         "styles.css"
       ],
       "scripts": [],
-      "environmentSource": "src/environments/environment.ts",
+      "environmentSource": "environments/environment.ts",
       "environments": {
-        "dev": "src/environments/environment.ts",
-        "prod": "src/environments/environment.prod.ts"
+        "dev": "environments/environment.ts",
+        "prod": "environments/environment.prod.ts",
+        "travis": "environments/environment.travis.ts"
       }
     }
   ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ addons:
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
-script:
-  - yarn test
-  - yarn e2e
+jobs:
+  include:
+    - stage: test
+      script: yarn test
+    - stage: test
+      script: yarn e2e
+    - stage: test
+      script: yarn build -- --prod
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - stage: test
       script: yarn e2e
     - stage: test
-      script: yarn build -- --prod
+      script: yarn build -- --prod --env=travis
 
 notifications:
   email: false

--- a/src/environments/environment.travis.ts
+++ b/src/environments/environment.travis.ts
@@ -1,0 +1,9 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=prod` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in `.angular-cli.json`.
+
+export const environment = {
+  production: true,
+  baseHref: '/'
+};


### PR DESCRIPTION
use the `Build stages` feature of travis to run all tests ( and a prod build to make sure we can deploy) in parallel