### PR TITLE
Feature/cab 2658

### DIFF
--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -6,8 +6,8 @@
         <div [ngSwitch]="fieldToDisplay.displayType">
 
           <mat-form-field *ngSwitchCase="'autocomplete'">
-            <input type="text" matInput [formControlName]="fieldToDisplay.name"
-                   [name]="fieldToDisplay.name"
+            <input type="text" matInput [formControlName]="fieldToDisplay.key"
+                   [name]="fieldToDisplay.key"
                    [placeholder]="fieldToDisplay.label" [matAutocomplete]="auto">
             <mat-autocomplete #auto="matAutocomplete">
               <mat-option *ngFor="let option of fieldToDisplay.filteredOptions | async "
@@ -17,7 +17,7 @@
           </mat-form-field>
 
             <app-timestamp-picker *ngSwitchCase="'date'"
-              [formControlName]="fieldToDisplay.name"
+              [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
             >
             </app-timestamp-picker>
@@ -25,14 +25,14 @@
           <mat-form-field *ngSwitchCase="'checkbox'">
             <app-checkbox-input
               [fieldConfig]="fieldToDisplay"
-              [formControlName]="fieldToDisplay.name"
+              [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
             ></app-checkbox-input>
           </mat-form-field>
 
           <mat-form-field *ngSwitchCase="'student-autocomplete'">
             <app-student-autocomplete
-              [formControlName]="fieldToDisplay.name"
+              [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
             >
             </app-student-autocomplete>
@@ -40,8 +40,8 @@
           </mat-form-field>
 
           <mat-form-field *ngSwitchDefault>
-            <input matInput [formControlName]="fieldToDisplay.name"
-                   [name]="fieldToDisplay.name"
+            <input matInput [formControlName]="fieldToDisplay.key"
+                   [name]="fieldToDisplay.key"
                    [placeholder]="fieldToDisplay.label">
           </mat-form-field>
         </div>

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -21,7 +21,6 @@ import { User } from '../../user/shared/user';
 import { StudentAutocompleteComponent } from '../../shared/widgets/student-autocomplete/student-autocomplete.component';
 import { CheckboxInputComponent } from '../../shared/widgets/checkbox/checkbox-input.component';
 import { TimestampPickerComponent } from '../../shared/widgets/timestamp-picker/timestamp-picker.component';
-import * as moment from 'moment';
 
 class UserServiceMock extends UserService {
   constructor() {
@@ -74,12 +73,12 @@ describe('ContentMetadataComponent', () => {
     const editPageConfig = new ContentPageConfig();
     editPageConfig.pageName = 'test-edit-page';
     editPageConfig.fieldsToDisplay = [
-      { name: '1', label: 'First' },
-      { name: '2', label: 'Second' },
-      { name: '3', label: 'Third' },
-      { name: 'a', label: 'a' },
-      { name: 'd', label: 'd', displayType: 'date' },
-      { name: 't', label: 't', displayType: 'autocomplete', options: ['o1', 'o2', 'o3'] }
+      { key: '1', label: 'First' },
+      { key: '2', label: 'Second' },
+      { key: '3', label: 'Third' },
+      { key: 'a', label: 'a' },
+      { key: 'd', label: 'd', displayType: 'date' },
+      { key: 't', label: 't', displayType: 'autocomplete', options: ['o1', 'o2', 'o3'] }
     ];
     editPageConfig.viewPanel = false;
     component.pageConfig = editPageConfig;

--- a/src/app/content/content-metadata/content-metadata.component.ts
+++ b/src/app/content/content-metadata/content-metadata.component.ts
@@ -51,9 +51,9 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy {
         field.filteredOptions = fc.valueChanges
           .startWith(null)
           .map(x => (x ? this.filterOptions(x, field.options) : field.options.slice()));
-        group[field.name] = fc;
+        group[field.key] = fc;
       } else {
-        group[field.name] = new FormControl('');
+        group[field.key] = new FormControl('');
       }
     });
     return new FormGroup(group);
@@ -69,7 +69,7 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy {
       const metaDataForm: FormGroup = <FormGroup>this.formGroup.controls['metadata'];
       if (!isNullOrUndefined(metaDataForm)) {
         this.pageConfig.fieldsToDisplay.map(field => {
-          metaDataForm.get(field.name).patchValue(this.contentItem.metadata[field.name]);
+          metaDataForm.get(field.key).patchValue(this.contentItem.metadata[field.key]);
         });
       }
     }

--- a/src/app/content/create-page/create-page.component.spec.ts
+++ b/src/app/content/create-page/create-page.component.spec.ts
@@ -104,8 +104,10 @@ describe('CreatePageComponent', () => {
     const config = new Config();
     config.tenant = 'test-tenant';
     config.pages['test-page'] = searchPageConfig;
-    config.profile = 'testProfile';
-    config.account = 'testAccount';
+    config.contentConfig = {
+      account: 'testAccount',
+      profile: 'testProfile'
+    };
 
     activatedRoute.testData = { config: config };
 
@@ -138,7 +140,7 @@ describe('CreatePageComponent', () => {
     expect(contentItem.metadata['Account']).toBe('testAccount');
   });
   it('should populate the account replacing user template when preparing to save', () => {
-    component.config.account += '/${user}';
+    component.config.contentConfig.account += '/${user}';
     const contentItem = component.prepareSaveContentItem();
     expect(contentItem.metadata['Account']).toBe('testAccount/testUser');
   });

--- a/src/app/content/create-page/create-page.component.spec.ts
+++ b/src/app/content/create-page/create-page.component.spec.ts
@@ -87,16 +87,13 @@ describe('CreatePageComponent', () => {
 
     const createPageConfig = new ContentPageConfig();
     createPageConfig.fieldsToDisplay = [
-      { name: '1', label: '1' },
-      { name: '2', label: '2' },
-      { name: '3', label: '3' },
-      { name: 'a', label: 'a' }
+      { key: '1', label: '1' },
+      { key: '2', label: '2' },
+      { key: '3', label: '3' },
+      { key: 'a', label: 'a' }
     ];
     createPageConfig.buttons = [saveButton];
-    createPageConfig.onSave = [
-      { name: 'PublishStatus', value: 'Published' },
-      { name: 'AnotherOnSave', value: 'Value' }
-    ];
+    createPageConfig.onSave = [{ key: 'PublishStatus', value: 'Published' }, { key: 'AnotherOnSave', value: 'Value' }];
     createPageConfig.pageName = 'test-create-page';
     createPageConfig.viewPanel = true;
 

--- a/src/app/content/create-page/create-page.component.ts
+++ b/src/app/content/create-page/create-page.component.ts
@@ -83,8 +83,8 @@ export class CreatePageComponent implements OnInit, OnDestroy {
     for (const key of Object.keys(formModel.metadata)) {
       updatedContentItem.metadata[key] = formModel.metadata[key];
     }
-    updatedContentItem.metadata['ProfileId'] = this.config.profile;
-    updatedContentItem.metadata['Account'] = this.config.account.replace('${user}', this.user.userName);
+    updatedContentItem.metadata['ProfileId'] = this.config.contentConfig.profile;
+    updatedContentItem.metadata['Account'] = this.config.contentConfig.account.replace('${user}', this.user.userName);
 
     if (this.pageConfig.onSave) {
       this.pageConfig.onSave.forEach(metadataOverride => {

--- a/src/app/content/create-page/create-page.component.ts
+++ b/src/app/content/create-page/create-page.component.ts
@@ -88,7 +88,7 @@ export class CreatePageComponent implements OnInit, OnDestroy {
 
     if (this.pageConfig.onSave) {
       this.pageConfig.onSave.forEach(metadataOverride => {
-        updatedContentItem.metadata[metadataOverride.name] = metadataOverride.value;
+        updatedContentItem.metadata[metadataOverride.key] = metadataOverride.value;
       });
     }
 

--- a/src/app/content/edit-page/edit-page.component.spec.ts
+++ b/src/app/content/edit-page/edit-page.component.spec.ts
@@ -89,12 +89,12 @@ describe('EditPageComponent', () => {
 
     editPageConfig = new ContentPageConfig();
     editPageConfig.fieldsToDisplay = [
-      { name: '1', label: '1' },
-      { name: '2', label: '2' },
-      { name: '3', label: '3' },
-      { name: 'a', label: 'a' },
-      { name: 'd', label: 'd', dataType: 'date' },
-      { name: 't', label: 't', dataType: 'string', displayType: 'typeahead', options: ['o1', 'o2'] }
+      { key: '1', label: '1' },
+      { key: '2', label: '2' },
+      { key: '3', label: '3' },
+      { key: 'a', label: 'a' },
+      { key: 'd', label: 'd', dataType: 'date' },
+      { key: 't', label: 't', dataType: 'string', displayType: 'typeahead', options: ['o1', 'o2'] }
     ];
     editPageConfig.buttons = [deleteButton, saveButton];
 

--- a/src/app/content/edit-page/edit-page.component.ts
+++ b/src/app/content/edit-page/edit-page.component.ts
@@ -100,7 +100,7 @@ export class EditPageComponent implements OnInit, OnDestroy, OnChanges {
     const updatedContentItem = new ContentItem(this.contentItem);
 
     this.pageConfig.fieldsToDisplay.map(field => {
-      updatedContentItem.metadata[field.name] = formModel.metadata[field.name];
+      updatedContentItem.metadata[field.key] = formModel.metadata[field.key];
     });
 
     return updatedContentItem;

--- a/src/app/core/shared/model/config.ts
+++ b/src/app/core/shared/model/config.ts
@@ -3,10 +3,14 @@ import { PageConfig } from './page-config';
 export class Config {
   appName: string;
   tenant: string;
-  profile: string;
-  account: string;
+  contentConfig: ContentConfig;
   pages: Map<string, PageConfig> = new Map<string, PageConfig>();
   customText: Map<string, CustomTextItem>;
+}
+
+export class ContentConfig {
+  profile: string;
+  account: string;
 }
 
 export class CustomTextItem {

--- a/src/app/core/shared/model/field.ts
+++ b/src/app/core/shared/model/field.ts
@@ -1,7 +1,7 @@
 import { CheckboxOptions } from './field/checkbox-options';
 
 export class Field {
-  public name: string;
+  public key: string;
   public label: string;
 
   public dataType?: string;

--- a/src/app/search/search-results/search-results.component.html
+++ b/src/app/search/search-results/search-results.component.html
@@ -24,7 +24,7 @@
       </mat-cell>
     </ng-container>
 
-    <ng-container *ngFor="let col of pageConfig.fieldsToDisplay" matColumnDef={{col.name}}>
+    <ng-container *ngFor="let col of pageConfig.fieldsToDisplay" matColumnDef={{col.key}}>
       <span [ngSwitch]="col.sortable">
          <span *ngSwitchCase="false">
           <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
@@ -35,7 +35,7 @@
       </span>
 
       <mat-cell *matCellDef="let element">
-        <app-display-field [field]="col" [value]="element.metadata[col.name]"></app-display-field>
+        <app-display-field [field]="col" [value]="element.metadata[col.key]"></app-display-field>
       </mat-cell>
 
 

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -48,7 +48,7 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
       this.data.storage = results.results.map(result => result['id']); // store a list of result ids to be passed to edit page
     });
     for (const field of this.pageConfig.fieldsToDisplay) {
-      this.displayedColumns.push(field.name);
+      this.displayedColumns.push(field.key);
     }
 
     this.sort.sortChange.subscribe((sort: Sort) => {

--- a/src/app/search/shared/search.service.spec.ts
+++ b/src/app/search/shared/search.service.spec.ts
@@ -197,7 +197,7 @@ describe('SearchService', () => {
 
     const pageConfig = new PageConfig();
     const field = new Field();
-    field.name = 'myfield';
+    field.key = 'myfield';
     field.displayType = 'string';
     pageConfig.fieldsToDisplay.push(field);
 

--- a/src/app/search/shared/search.service.ts
+++ b/src/app/search/shared/search.service.ts
@@ -130,7 +130,7 @@ export class SearchService {
   private addOrderingToSearchPayload(searchPayload: any, order: SearchOrder, pageConfig: PageConfig) {
     if (order && order.term && order.order) {
       const newOrder: SearchOrder = Object.assign(new SearchOrder(), order);
-      const fieldConfig: Field = pageConfig.fieldsToDisplay.find(field => field.name === newOrder.term);
+      const fieldConfig: Field = pageConfig.fieldsToDisplay.find(field => field.key === newOrder.term);
 
       if (newOrder.term !== 'id' && newOrder.term !== 'label') {
         newOrder.term = 'metadata.' + newOrder.term;
@@ -141,7 +141,7 @@ export class SearchService {
       if (
         fieldConfig &&
         (!fieldConfig.dataType || fieldConfig.dataType === 'string') &&
-        !fieldConfig.name.endsWith('Date')
+        !fieldConfig.key.endsWith('Date')
       ) {
         newOrder.term += '.lowercase';
       }

--- a/src/app/shared/widgets/display-field/display-field.component.spec.ts
+++ b/src/app/shared/widgets/display-field/display-field.component.spec.ts
@@ -29,7 +29,7 @@ describe('DisplayFieldComponent', () => {
   });
   it('should display a date', () => {
     component.value = 1511292577000;
-    component.field = { name: 'displayDate', label: 'displayDate', displayType: 'date' };
+    component.field = { key: 'displayDate', label: 'displayDate', displayType: 'date' };
 
     fixture.detectChanges();
 
@@ -42,7 +42,7 @@ describe('DisplayFieldComponent', () => {
     const date = new Date();
 
     component.value = date.getTime();
-    component.field = { name: 'displayDate', label: 'displayDate', displayType: 'dateTime' };
+    component.field = { key: 'displayDate', label: 'displayDate', displayType: 'dateTime' };
 
     fixture.detectChanges();
 
@@ -55,7 +55,7 @@ describe('DisplayFieldComponent', () => {
   });
   it('should use the student-display componenent when a student', () => {
     component.value = '1234';
-    component.field = { name: 'displayDate', label: 'displayDate', displayType: 'student' };
+    component.field = { key: 'displayDate', label: 'displayDate', displayType: 'student' };
 
     fixture.detectChanges();
 
@@ -65,7 +65,7 @@ describe('DisplayFieldComponent', () => {
   });
   it('should default to displaying the passed in value', () => {
     component.value = 1511292577000;
-    component.field = { name: 'displayDate', label: 'displayDate', displayType: 'aFakeType' };
+    component.field = { key: 'displayDate', label: 'displayDate', displayType: 'aFakeType' };
 
     fixture.detectChanges();
 


### PR DESCRIPTION

- Replace the attribute name "name" with "key" throughout
- Wrap the profile and account attributes inside of a new 'contentConfig' object