### PR TITLE
Feature/CAB-2645 refactoring to fix issue with returning to a default search

### DIFF
--- a/src/app/core/shared/model/search-page-config.ts
+++ b/src/app/core/shared/model/search-page-config.ts
@@ -2,7 +2,7 @@ import { FacetsConfig } from './facets-config';
 import { SearchConfig } from './search-config';
 import { Field } from './field';
 import { PageConfig } from './page-config';
-import { SearchOrder } from '../../../search/shared/model/search-order';
+import { Sort } from '../../../search/shared/model/sort';
 
 export class SearchPageConfig implements PageConfig {
   pageName: string;
@@ -12,5 +12,5 @@ export class SearchPageConfig implements PageConfig {
 
   facetsConfig: FacetsConfig = new FacetsConfig();
   searchConfig: SearchConfig = new SearchConfig();
-  defaultOrder: SearchOrder = new SearchOrder();
+  defaultSort: Sort = new Sort();
 }

--- a/src/app/search/search-page/search-page.component.spec.ts
+++ b/src/app/search/search-page/search-page.component.spec.ts
@@ -99,7 +99,7 @@ describe('SearchPageComponent', () => {
   });
 
   it('should add default sort order if none is defined in the pageConfig', () => {
-    expect(component.pageConfig.defaultOrder.term).toBe('id');
-    expect(component.pageConfig.defaultOrder.order).toBe('desc');
+    expect(component.pageConfig.defaultSort.term).toBe('id');
+    expect(component.pageConfig.defaultSort.order).toBe('desc');
   });
 });

--- a/src/app/search/search-page/search-page.component.ts
+++ b/src/app/search/search-page/search-page.component.ts
@@ -8,7 +8,7 @@ import { SearchResults } from '../shared/model/search-result';
 import { SearchService } from '../shared/search.service';
 import { Subject } from 'rxjs/Subject';
 import { DataService } from '../../shared/providers/data.service';
-import { SearchOrder } from '../shared/model/search-order';
+import { Sort } from '../shared/model/sort';
 import { isNullOrUndefined } from 'util';
 
 @Component({
@@ -34,8 +34,9 @@ export class SearchPageComponent implements OnInit, OnDestroy, AfterViewInit {
   ) {}
 
   ngAfterViewInit(): void {
-    if (this.dataService.get('currentSearch')) {
-      this.searchModel$.next(Object.assign(new SearchModel(), this.dataService.get('currentSearch')));
+    const cachedSearch = this.dataService.get('currentSearch');
+    if (cachedSearch) {
+      this.searchModel$.next(Object.assign(new SearchModel(), cachedSearch));
     }
   }
 
@@ -48,11 +49,11 @@ export class SearchPageComponent implements OnInit, OnDestroy, AfterViewInit {
         this.config = data.config;
         this.pageConfig = data.config.pages[this.page.toLowerCase()];
         if (
-          isNullOrUndefined(this.pageConfig.defaultOrder) ||
-          isNullOrUndefined(this.pageConfig.defaultOrder.term) ||
-          isNullOrUndefined(this.pageConfig.defaultOrder.order)
+          isNullOrUndefined(this.pageConfig.defaultSort) ||
+          isNullOrUndefined(this.pageConfig.defaultSort.term) ||
+          isNullOrUndefined(this.pageConfig.defaultSort.order)
         ) {
-          this.pageConfig.defaultOrder = new SearchOrder('id', 'desc');
+          this.pageConfig.defaultSort = new Sort('id', 'desc');
         }
         this.titleService.setTitle(this.pageConfig.pageName);
         this.searchService.search(this.searchModel$, this.pageConfig).subscribe((searchResults: SearchResults) => {

--- a/src/app/search/search-results/search-results.component.html
+++ b/src/app/search/search-results/search-results.component.html
@@ -7,7 +7,7 @@
                  (page)="onPageEvent($event)">
   </mat-paginator>
 
-  <mat-table #table [dataSource]="dataSource" matSort aria-label="Search Results">
+  <mat-table #table [dataSource]="dataSource" matSort [matSortActive]="sortTerm" [matSortDirection]="sortDirection" aria-label="Search Results">
 
     <!--- Note that these columns can be defined in any order.
         The actual rendered columns are set as a property on the row definition" -->

--- a/src/app/search/search-results/search-results.component.spec.ts
+++ b/src/app/search/search-results/search-results.component.spec.ts
@@ -59,6 +59,12 @@ describe('SearchResultsComponent', () => {
   });
 
   it('should set sort order if defaultSort is defined in the pageConfig', () => {
+    component.searchResults$.next(new SearchResults());
+    fixture.detectChanges();
+    expect(component.sortTerm).toBe('myfield');
+    expect(component.sortDirection).toBe('asc');
+    // This verifies that the change is being passed successfully through the databinding and that the
+    // event on the matSort object is being digested correctly
     expect(component.sort.active).toBe('myfield');
     expect(component.sort.direction).toBe('asc');
   });

--- a/src/app/search/search-results/search-results.component.spec.ts
+++ b/src/app/search/search-results/search-results.component.spec.ts
@@ -12,7 +12,9 @@ import { SearchResults } from '../shared/model/search-result';
 import { DataService } from '../../shared/providers/data.service';
 import { SharedModule } from '../../shared/shared.module';
 import { ActivatedRouteStub } from '../../../testing/router-stubs';
-import { SearchOrder } from '../shared/model/search-order';
+import { Sort } from '../shared/model/sort';
+import { Subject } from 'rxjs/Subject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 
 class MockDataService {
   storage = ['123', '456'];
@@ -45,9 +47,9 @@ describe('SearchResultsComponent', () => {
     searchModel.stringQuery = 'iSearch';
     component.searchModel$ = Observable.of(searchModel);
     component.pageConfig = new SearchPageConfig();
-    component.pageConfig.defaultOrder = new SearchOrder('myfield', 'asc');
-    const searchResults = new SearchResults();
-    component.searchResults$ = Observable.of(searchResults);
+    component.pageConfig.defaultSort = new Sort('myfield', 'asc');
+    component.searchResults$ = new Subject<SearchResults>();
+    component.searchResults$.next(new SearchResults());
 
     fixture.detectChanges();
   });
@@ -56,8 +58,21 @@ describe('SearchResultsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should set sort order if defaultOrder is defined in the pageConfig', () => {
+  it('should set sort order if defaultSort is defined in the pageConfig', () => {
     expect(component.sort.active).toBe('myfield');
     expect(component.sort.direction).toBe('asc');
+  });
+
+  it('should change sort order when a new sort is defined in the search results', () => {
+    const sort = new Sort('newfield', 'desc');
+    component.searchResults$.next(new SearchResults(sort));
+    fixture.detectChanges();
+    // This verifies that the variables are being directly set in the subscription method
+    expect(component.sortTerm).toBe('newfield');
+    expect(component.sortDirection).toBe('desc');
+    // This verifies that the change is being passed successfully through the databinding and that the
+    // event on the matSort object is being digested correctly
+    expect(component.sort.active).toBe('newfield');
+    expect(component.sort.direction).toBe('desc');
   });
 });

--- a/src/app/search/shared/model/search-datasource.model.ts
+++ b/src/app/search/shared/model/search-datasource.model.ts
@@ -4,15 +4,31 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/merge';
 import { SearchResults } from './search-result';
 import { ResultRow } from './result-row';
-import { MatPaginator, MatSort } from '@angular/material';
+import { MatPaginator, MatSort, SortDirection } from '@angular/material';
+import { SearchModel } from './search-model';
+import { isNullOrUndefined } from 'util';
 
 export class SearchDataSource extends DataSource<ResultRow> {
   constructor(
+    private searchModel$: Observable<SearchModel>,
     private searchResults$: Observable<SearchResults>,
     private sort: MatSort,
     private paginators: Array<MatPaginator>
   ) {
     super();
+    searchModel$.subscribe(searchModel => {
+      if (!isNullOrUndefined(searchModel)) {
+        const newSort = searchModel.order;
+        let newSortDirection: SortDirection = '';
+        if (newSort.order === 'asc') {
+          newSortDirection = 'asc';
+        } else if (newSort.order === 'desc') {
+          newSortDirection = 'desc';
+        }
+        this.sort.active = newSort.term;
+        this.sort.direction = newSortDirection;
+      }
+    });
   }
 
   connect(): Observable<ResultRow[]> {

--- a/src/app/search/shared/model/search-model.ts
+++ b/src/app/search/shared/model/search-model.ts
@@ -1,13 +1,13 @@
 import { SearchFilter } from './search-filter';
 import { PaginatorConfig } from './paginator-config';
-import { SearchOrder } from './search-order';
+import { Sort } from './sort';
 import { isNullOrUndefined } from 'util';
 
 export class SearchModel {
   stringQuery: string;
   private _filters: SearchFilter[] = [];
   pagination: PaginatorConfig = new PaginatorConfig();
-  order: SearchOrder = new SearchOrder();
+  order: Sort = new Sort();
 
   get filters(): SearchFilter[] {
     return this._filters;

--- a/src/app/search/shared/model/search-order.ts
+++ b/src/app/search/shared/model/search-order.ts
@@ -1,5 +1,3 @@
-import { isNullOrUndefined } from 'util';
-
 export class SearchOrder {
   term: string;
   /**

--- a/src/app/search/shared/model/search-result.ts
+++ b/src/app/search/shared/model/search-result.ts
@@ -1,12 +1,15 @@
 import { ResultRow } from './result-row';
 import { Facet } from './facet';
+import { Sort } from './sort';
 
 export class SearchResults {
   results: ResultRow[] = [];
   facets: Map<string, Facet>;
   total: number;
+  sort: Sort;
 
-  constructor() {
+  constructor(sort?: Sort) {
     this.facets = new Map<string, Facet>();
+    this.sort = sort;
   }
 }

--- a/src/app/search/shared/model/sort.ts
+++ b/src/app/search/shared/model/sort.ts
@@ -1,4 +1,4 @@
-export class SearchOrder {
+export class Sort {
   term: string;
   /**
    * Sets the value when a field is missing in a doc.

--- a/src/app/search/shared/search-utility.ts
+++ b/src/app/search/shared/search-utility.ts
@@ -1,0 +1,12 @@
+import { SortDirection } from '@angular/material';
+
+export class SearchUtility {
+  public static castSortDirection(direction: string): SortDirection {
+    if (direction === 'asc') {
+      return 'asc';
+    } else if (direction === 'desc') {
+      return 'desc';
+    }
+    return '';
+  }
+}

--- a/src/app/search/shared/search.service.spec.ts
+++ b/src/app/search/shared/search.service.spec.ts
@@ -10,7 +10,7 @@ import { SearchFilter } from './model/search-filter';
 import { Field } from '../../core/shared/model/field';
 import { HttpClient } from '@angular/common/http';
 import { DataService } from '../../shared/providers/data.service';
-import { SearchOrder } from './model/search-order';
+import { Sort } from './model/sort';
 
 class UserServiceMock extends UserService {
   constructor() {
@@ -198,7 +198,7 @@ describe('SearchService', () => {
     httpSpy = spyOn(http, 'post').and.returnValue(Observable.of(new Response(new ResponseOptions())));
 
     const searchPageConfig = new SearchPageConfig();
-    searchPageConfig.defaultOrder = new SearchOrder('mydefaultfield', 'desc');
+    searchPageConfig.defaultSort = new Sort('mydefaultfield', 'desc');
     searchService.search(Observable.of(searchModel), searchPageConfig).subscribe(result => {
       expect(httpSpy).toHaveBeenCalledTimes(1);
       // args[1] is the payload
@@ -218,7 +218,7 @@ describe('SearchService', () => {
     httpSpy = spyOn(http, 'post').and.returnValue(Observable.of(new Response(new ResponseOptions())));
 
     const searchPageConfig = new SearchPageConfig();
-    searchPageConfig.defaultOrder = new SearchOrder('mydefaultfield', 'desc');
+    searchPageConfig.defaultSort = new Sort('mydefaultfield', 'desc');
     searchService.search(Observable.of(searchModel), searchPageConfig).subscribe(result => {
       expect(httpSpy).toHaveBeenCalledTimes(1);
       // args[1] is the payload

--- a/src/app/search/shared/search.service.ts
+++ b/src/app/search/shared/search.service.ts
@@ -12,7 +12,7 @@ import { UserService } from '../../user/shared/user.service';
 import { SearchFilter } from './model/search-filter';
 import { SearchPageConfig } from '../../core/shared/model/search-page-config';
 import { FacetConfig } from '../../core/shared/model/facet-config';
-import { SearchOrder } from './model/search-order';
+import { Sort } from './model/sort';
 import { Field } from '../../core/shared/model/field';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { DataService } from '../../shared/providers/data.service';
@@ -24,27 +24,27 @@ export class SearchService {
 
   constructor(private http: HttpClient, private userService: UserService, private dataService: DataService) {}
 
-  search(terms: Observable<SearchModel>, pageConfig: SearchPageConfig): Observable<SearchResults> {
-    return terms
+  search(searchModel$: Observable<SearchModel>, pageConfig: SearchPageConfig): Observable<SearchResults> {
+    return searchModel$
       .debounceTime(400)
       .distinctUntilChanged()
-      .switchMap(term => {
+      .switchMap(searchModel => {
         console.log('processing search request');
 
-        this.dataService.set('currentSearch', term);
+        this.dataService.set('currentSearch', searchModel);
 
-        return this.searchEntries(term, pageConfig);
+        return this.searchEntries(searchModel, pageConfig);
       });
   }
 
-  private searchEntries(term: SearchModel, pageConfig: SearchPageConfig): Observable<SearchResults> {
+  private searchEntries(searchModel: SearchModel, pageConfig: SearchPageConfig): Observable<SearchResults> {
     const indexName = pageConfig.searchConfig.indexName;
-    const searchPayload = this.buildSearchPayload(term, pageConfig);
+    const searchPayload = this.buildSearchPayload(searchModel, pageConfig);
     const options = this.buildRequestOptions();
 
     console.log('searching "' + indexName + '" with ' + JSON.stringify(searchPayload));
     return this.http.post(this.baseUrl + indexName, searchPayload, options).map(response => {
-      return this.convertSearchApiResultsToSearchResults(response);
+      return this.convertSearchApiResultsToSearchResults(searchModel, response);
     });
   }
 
@@ -66,12 +66,12 @@ export class SearchService {
     this.addFacetsToSearchPayload(searchPayload, pageConfig);
     this.addFiltersToSearchPayload(searchPayload, term);
     this.addPaginationToSearchPayload(searchPayload, term);
-    this.addOrderingToSearchPayload(searchPayload, term.order, pageConfig);
+    this.addSortToSearchPayload(searchPayload, term.order, pageConfig);
     return searchPayload;
   }
 
-  convertSearchApiResultsToSearchResults(apiResult: any) {
-    const results = new SearchResults();
+  convertSearchApiResultsToSearchResults(searchModel: SearchModel, apiResult: any) {
+    const results = new SearchResults(searchModel.order);
 
     if (apiResult !== null) {
       if ('totalCount' in apiResult) {
@@ -132,24 +132,24 @@ export class SearchService {
     searchPayload['facets'] = facets;
   }
 
-  private addOrderingToSearchPayload(searchPayload: any, order: SearchOrder, pageConfig: SearchPageConfig) {
-    if (isNullOrUndefined(order) || isNullOrUndefined(order.term) || isNullOrUndefined(order.order)) {
-      order = pageConfig.defaultOrder;
+  private addSortToSearchPayload(searchPayload: any, sort: Sort, pageConfig: SearchPageConfig) {
+    if (isNullOrUndefined(sort) || isNullOrUndefined(sort.term) || isNullOrUndefined(sort.order)) {
+      sort = pageConfig.defaultSort;
     }
-    if (order && order.term && order.order) {
-      const newOrder: SearchOrder = Object.assign(new SearchOrder(), order);
-      const fieldConfig: Field = pageConfig.fieldsToDisplay.find(field => field.key === newOrder.term);
+    if (sort && sort.term && sort.order) {
+      const newSort: Sort = Object.assign(new Sort(), sort);
+      const fieldConfig: Field = pageConfig.fieldsToDisplay.find(field => field.key === newSort.term);
 
-      if (newOrder.term !== 'id' && newOrder.term !== 'label') {
-        newOrder.term = 'metadata.' + newOrder.term;
-      } else if (newOrder.term !== 'id') {
-        newOrder.term += '.lowercase';
+      if (newSort.term !== 'id' && newSort.term !== 'label') {
+        newSort.term = 'metadata.' + newSort.term;
+      } else if (newSort.term !== 'id') {
+        newSort.term += '.lowercase';
       }
 
       if (fieldConfig) {
         if (fieldConfig.dataType) {
           if (fieldConfig.dataType === 'string' && !fieldConfig.key.endsWith('Date')) {
-            newOrder.term += '.lowercase';
+            newSort.term += '.lowercase';
           } else if (fieldConfig.dataType === 'number') {
             // NOOP
           } else if (fieldConfig.dataType === 'date') {
@@ -158,7 +158,7 @@ export class SearchService {
         }
       }
 
-      searchPayload['searchOrder'] = newOrder;
+      searchPayload['searchOrder'] = newSort;
     }
   }
 }


### PR DESCRIPTION
I did some renaming of classes here to try to make names clearer - didn't change SearchModel.order because I think that might be used in the Search API, but it is confusing that we have references to SearchModel.order.order, I think.