### PR TITLE
Remove daterange-picker cancel, clear, apply buttons

### DIFF
--- a/e2e/mocks/profile-api/demo.json
+++ b/e2e/mocks/profile-api/demo.json
@@ -50,6 +50,16 @@
         "placeholder": "Search for documents",
         "indexName": "documents-demo"
       },
+      "searchDaterangeConfig": {
+        "active": true,
+        "filterKey": "metadata.ReceivedDate.raw",
+        "filterLabel": "ReceivedDate",
+        "showCalendar": true,
+        "showRelativeRange": true,
+        "placeholder": "Choose Received Date",
+        "displayRangeLabelInsteadOfDates": true,
+        "showDropdowns": true
+      },
       "facetsConfig": {
         "active": true,
         "facets": {

--- a/src/app/search/search-daterange-picker/search-daterange-picker.component.html
+++ b/src/app/search/search-daterange-picker/search-daterange-picker.component.html
@@ -6,8 +6,10 @@
          [showRangeLabelOnInput]="showRangeLabelOnInput"
          [alwaysShowCalendars]="alwaysShowCalendars"
          [placeholder]="placeholder"
-         [showClearButton]="showClearButton"
          [showDropdowns]="showDropdowns"
          [attr.aria-label]="placeholder"
+         (datesUpdated)="datesUpdated($event)"
+         (rangeClicked)="datesUpdated($event)"
+         autoApply="false"
          />
 </mat-form-field>

--- a/src/app/search/search-daterange-picker/search-daterange-picker.component.spec.ts
+++ b/src/app/search/search-daterange-picker/search-daterange-picker.component.spec.ts
@@ -54,15 +54,6 @@ describe('SearchDaterangePickerComponent', () => {
     expect(component.searchModel.filters[0].label).toBe('testLabel');
   });
 
-  it('should clear daterange filter', () => {
-    const existingFilter = new SearchFilter('testKey', 'testDateRange', 'testLabel');
-    component.searchModel.filters[0] = existingFilter;
-
-    component.formGroup.controls['internalDateRange'].patchValue({ startDate: null, endDate: null });
-    fixture.detectChanges();
-    expect(component.searchModel.filters.length).toBe(0);
-  });
-
   it('should replace existing daterange filter', () => {
     const existingFilter = new SearchFilter('testKey', 'testDateRange', 'testLabel');
     component.searchModel.filters[0] = existingFilter;
@@ -88,7 +79,7 @@ describe('SearchDaterangePickerComponent', () => {
 
     const startDate: Moment = moment('01-01-2018', 'MM-DD-YYYY');
     const endDate: Moment = moment('02-01-2018', 'MM-DD-YYYY');
-    component.formGroup.controls['internalDateRange'].patchValue({ startDate: startDate, endDate: endDate });
-    fixture.detectChanges();
+
+    component.datesUpdated({ startDate: startDate, endDate: endDate });
   });
 });

--- a/src/app/search/search-daterange-picker/search-daterange-picker.component.ts
+++ b/src/app/search/search-daterange-picker/search-daterange-picker.component.ts
@@ -35,24 +35,26 @@ export class SearchDaterangePickerComponent implements OnInit, OnDestroy {
   constructor(private fb: FormBuilder) {}
 
   ngOnInit() {
-    this.formGroup = this.fb.group({
-      internalDateRange: new FormControl()
-    });
+    this.formGroup = this.fb.group({});
+    this.formGroup.controls['internalDateRange'] = new FormControl();
     this.searchModel$.takeUntil(this.componentDestroyed).subscribe(searchModel => {
       this.searchModel = searchModel;
+      // TODO: if filter is removed, clear daterange-picker textfield
     });
 
-    this.formGroup.controls['internalDateRange'].valueChanges
-      .startWith(null)
-      .takeUntil(this.componentDestroyed)
-      .subscribe(selected => {
-        if (selected) {
-          const startDate: Moment = this.createLosAngelesMoment(selected.startDate);
-          const endDate: Moment = this.createLosAngelesMoment(selected.endDate);
-          this.addDateRangeFilter(startDate, endDate);
-        }
-      });
     this.loadPageConfig();
+  }
+
+  datesUpdated(selected) {
+    if (
+      selected &&
+      ((selected.startDate && selected.endDate) ||
+        (isNullOrUndefined(selected.startDate) && isNullOrUndefined(selected.endDate)))
+    ) {
+      const startDate: Moment = this.createLosAngelesMoment(selected.startDate);
+      const endDate: Moment = this.createLosAngelesMoment(selected.endDate);
+      this.addDateRangeFilter(startDate, endDate);
+    }
   }
 
   private createLosAngelesMoment(aMoment: Moment) {


### PR DESCRIPTION
* Remove daterange-picker cancel, clear, apply buttons -- apply on select

* Known bug, when clearing the daterange filter, the daterange-picker field does not clear -- we are planning to replace this component with the angular material2 picker ( https://github.com/angular/material2/issues/4763 ) when it is released