### PR TITLE
Cab 3633

### DIFF
--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -1,7 +1,7 @@
 <div [formGroup]="formGroup" class="cs-content-metadata">
   <ul *ngIf="pageConfig?.fieldsToDisplay" class="fields">
     <div formGroupName="metadata">
-      <li *ngFor="let fieldToDisplay of pageConfig.fieldsToDisplay">
+      <li *ngFor="let fieldToDisplay of pageConfig.fieldsToDisplay; index as i">
         <div [ngSwitch]="fieldToDisplay.displayType">
 
           <mat-form-field *ngSwitchCase="'select'">
@@ -11,6 +11,8 @@
               [fieldConfig]="fieldToDisplay"
               [parentControl]="formGroup.get('metadata').get(fieldToDisplay.dynamicSelectConfig?.parentFieldConfig?.key || '')"
               [required]="formGroup.get('metadata').get(fieldToDisplay.key).errors !== null && formGroup.get('metadata').get(fieldToDisplay.key).errors.required"
+              [id]="'custom-input-'+ i"
+              [attr.id]="'custom-input-'+ i"
             >
             </app-options-input>
             <mat-error>
@@ -33,6 +35,8 @@
               [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
               [required]="formGroup.get('metadata').get(fieldToDisplay.key).errors !== null && formGroup.get('metadata').get(fieldToDisplay.key).errors.required"
+              [id]="'custom-input-'+ i"
+              [attr.id]="'custom-input-'+ i"
             ></app-checkbox-input>
             <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
           </mat-form-field>
@@ -42,6 +46,8 @@
               [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
               [required]="formGroup.get('metadata').get(fieldToDisplay.key).errors !== null && formGroup.get('metadata').get(fieldToDisplay.key).errors.required"
+              [id]="'custom-input-'+ i"
+              [attr.id]="'custom-input-'+ i"
             >
             </app-student-autocomplete>
             <mat-error>Please select a valid {{fieldToDisplay.label}}</mat-error>
@@ -52,6 +58,8 @@
               [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
               [required]="formGroup.get('metadata').get(fieldToDisplay.key).errors !== null && formGroup.get('metadata').get(fieldToDisplay.key).errors.required"
+              [id]="'custom-input-'+ i"
+              [attr.id]="'custom-input-'+ i"
             >
             </app-person-autocomplete>
             <mat-error>Please select a valid {{fieldToDisplay.label}}</mat-error>

--- a/src/app/content/content-object-list/content-object-list.component.html
+++ b/src/app/content/content-object-list/content-object-list.component.html
@@ -3,9 +3,6 @@
     <mat-list-item *ngFor="let contentObject of contentObjects; let i = index" [ngClass]="selectedIndex > -1 && i == selectedIndex ? 'cs-selected' : ''">
  
         <p matLine (click)="selectObject(i)">
-            <button mat-icon-button>
-                <mat-icon [ngClass]="contentObject.failed ? 'hasError' : ''">{{ contentObject.persisted ? 'cloud_circle' : 'description' }}</mat-icon>
-            </button>
             <span>{{ contentObject.getOriginalFileName() }}</span>
         </p>
 

--- a/src/app/content/content-toolbar/content-toolbar.component.html
+++ b/src/app/content/content-toolbar/content-toolbar.component.html
@@ -24,7 +24,7 @@
         <span class="cs-fill-remaining-space"></span>
         <span *ngIf="contentType === 'pdf'">
             <mat-form-field class="medium-field">
-                <mat-select [ngModel]="zoomFactor" (ngModelChange)="changeZoomFactor($event)" class="cs-zoom-factor-select" name="zoomFactor" ngDefaultControl>
+                <mat-select [ngModel]="zoomFactor" (ngModelChange)="changeZoomFactor($event)" class="cs-zoom-factor-select" name="zoomFactor" aria-label="Zoom" ngDefaultControl>
                     <mat-option value="automatic-zoom">Automatic Zoom</mat-option>
                     <mat-option value="actual-size">Actual Size</mat-option>
                     <mat-option value="page-width">Page Width</mat-option>

--- a/src/app/content/content-toolbar/content-toolbar.component.html
+++ b/src/app/content/content-toolbar/content-toolbar.component.html
@@ -50,7 +50,7 @@
             <span>of {{pageCount}}</span>
         </span>
         <span *ngIf="allowFullScreen" class="button-row">
-            <button mat-icon-button (click)="toggleFullScreen()" role="button">
+            <button mat-icon-button (click)="toggleFullScreen()" role="button" [attr.aria-label]="fullScreen ? 'Exit full screen mode' : 'Full screen mode'" >
                 <mat-icon>{{fullScreen ? 'fullscreen_exit' : 'fullscreen'}}</mat-icon>
             </button>
         </span>

--- a/src/app/shared/widgets/file-upload/file-upload.component.html
+++ b/src/app/shared/widgets/file-upload/file-upload.component.html
@@ -7,6 +7,7 @@
                (change)="onFileChange($event)"
                [formControlName]="fieldName"
                [multiple]="multiple"
+               role="button"
                aria-label="add file">
         <label [for]="fieldId" class="mat-icon-button" [appFocus]="autoFocus"
                [matTooltip]="label">


### PR DESCRIPTION
Notes on the invalid ID issue. My test indicated that the "id" property was used by "aria-own" attribute, and the "id" attribute was used to initialize the "id" of the "owned" element.  A static "id" attribute, e.g. id="custom-input-1", worked. But dynamic values [id] set the "id" property only, and I need to use both [id] and [attr.id] to solve the invalid issue.