### PR TITLE
Enable automated accessibility checks for Create and Edit pages.

### DIFF
--- a/e2e/create/create.local-spec.ts
+++ b/e2e/create/create.local-spec.ts
@@ -30,14 +30,25 @@ describe('Create Page for Demo', () => {
     return childrenLabels;
   };
 
-  const invalidDateErrMsg = 'The year must be a valid date between 1654 and 2285';
+  const enterDateAndVerifyErrorMsg = function(date: string) {
+    page.dateInputField.first().sendKeys(date);
+    page.dateInputField.first().sendKeys(protractor.Key.TAB);
+
+    browser.wait(protractor.ExpectedConditions.visibilityOf(page.metadataErrorMessages.first()), 10000);
+    const invalidDateErrMsg = 'The year must be a valid date between 1654 and 2285';
+    expect(page.metadataErrorMessages.first().getText()).toEqual(invalidDateErrMsg);
+    expect(page.saveButton.isEnabled()).toBeFalsy();
+
+    page.clickCancelButton();
+    page.clickAcceptAlert();
+  };
 
   beforeEach(() => {
     page = new CreatePage();
     page.navigateTo();
   });
 
-  xit('should have no accessibility violations', () => {
+  it('should have no accessibility violations', () => {
     const app = new ContentServicesUiPage();
     app.runAccessibilityChecks();
   });
@@ -227,25 +238,11 @@ describe('Create Page for Demo', () => {
   });
 
   it('should display error message and disable Save button when date text input is less than 1654', () => {
-    page.dateInputField.first().sendKeys('12/31/1653');
-    page.dateInputField.first().sendKeys(protractor.Key.TAB);
-
-    expect(page.metadataErrorMessages.first().getText()).toEqual(invalidDateErrMsg);
-    expect(page.saveButton.isEnabled()).toBeFalsy();
-
-    page.clickCancelButton();
-    page.clickAcceptAlert();
+    enterDateAndVerifyErrorMsg('12/31/1653');
   });
 
   it('should display error message and disable Save button when date text input is greater than 2285', () => {
-    page.dateInputField.first().sendKeys('1/1/2286');
-    page.dateInputField.first().sendKeys(protractor.Key.TAB);
-
-    expect(page.metadataErrorMessages.first().getText()).toEqual(invalidDateErrMsg);
-    expect(page.saveButton.isEnabled()).toBeFalsy();
-
-    page.clickCancelButton();
-    page.clickAcceptAlert();
+    enterDateAndVerifyErrorMsg('1/1/2286');
   });
 
   it('should disable calendar picker less than 1654', () => {
@@ -285,6 +282,11 @@ describe('Create Page for Demo2', () => {
   beforeEach(() => {
     page = new CreatePage('demo2');
     page.navigateTo();
+  });
+
+  it('should have no accessibility violations', () => {
+    const app = new ContentServicesUiPage();
+    app.runAccessibilityChecks();
   });
 
   it('should disable Save button when required field is not populated', () => {

--- a/e2e/edit/edit.local-spec.ts
+++ b/e2e/edit/edit.local-spec.ts
@@ -29,7 +29,7 @@ describe('Edit Page for Demo', () => {
     page.navigateTo();
   });
 
-  xit('should have no accessibility violations', () => {
+  it('should have no accessibility violations', () => {
     const app = new ContentServicesUiPage();
     app.runAccessibilityChecks();
   });
@@ -205,6 +205,11 @@ describe('Edit Page for Demo2', () => {
 
   beforeEach(() => {
     page.navigateTo();
+  });
+
+  it('should have no accessibility violations', () => {
+    const app = new ContentServicesUiPage();
+    app.runAccessibilityChecks();
   });
 
   it('should not display alert when the page has disabled fields and no changes are made', () => {

--- a/e2e/search/display-search.local-spec.ts
+++ b/e2e/search/display-search.local-spec.ts
@@ -13,7 +13,7 @@ describe('Search Display All Page', () => {
     page.navigateTo();
   });
 
-  it('should have no accessibility violations', () => {
+  xit('should have no accessibility violations', () => {
     const app = new ContentServicesUiPage();
     app.runAccessibilityChecks();
   });

--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -1,9 +1,8 @@
 <div [formGroup]="formGroup" class="cs-content-metadata">
-  <ul *ngIf="pageConfig?.fieldsToDisplay" class="fields">
-    <div formGroupName="metadata">
+  <div formGroupName="metadata">
+    <ul *ngIf="pageConfig?.fieldsToDisplay" class="fields">
       <li *ngFor="let fieldToDisplay of pageConfig.fieldsToDisplay; index as i">
         <div [ngSwitch]="fieldToDisplay.displayType">
-
           <mat-form-field *ngSwitchCase="'select'">
             <app-options-input
               [formControlName]="fieldToDisplay.key"
@@ -17,7 +16,6 @@
             </app-options-input>
             <mat-error>
               {{getErrorMessage(fieldToDisplay.key)}}
-
             </mat-error>
           </mat-form-field>
           <app-timestamp-picker *ngSwitchCase="'date'"
@@ -76,6 +74,6 @@
           </mat-form-field>
         </div>
       </li>
-    </div>
-  </ul>
+    </ul>
+  </div>
 </div>


### PR DESCRIPTION
Turn off accessibility check for Search Display All page because it is inconsistent with iframes.
Rearrange div/ul because div is not allowed directly under ul.