### PR TITLE
Feature/cab 3699

### DIFF
--- a/e2e/mocks/profile-api/demo3.json
+++ b/e2e/mocks/profile-api/demo3.json
@@ -1,0 +1,278 @@
+{
+  "account": "demo-account",
+  "tenant": "Demo3",
+  "appName": "Demo 3: Disabled Edit Page",
+  "customText": {
+    "addContentItemButton": {
+      "label": "Upload",
+      "description": "Upload a new content item"
+    },
+    "nextContentItemButton": {
+      "label": "Next",
+      "description": "Move down to next content item"
+    },
+    "previousContentItemButton": {
+      "label": "Previous",
+      "description": "Move up to previous content item"
+    },"unsavedChangesMessage": {
+      "label": "Click OK to lose your changes."
+    }
+  },
+  "pages": {
+    "tab-search": {
+      "pageName": "Demonstration Search",
+      "theme": "uw-default",
+      "searchStateInURL": false,
+      "enableDisplaySearch": true,
+      "fieldsToDisplay": [
+        {
+          "key": "ProfileId",
+          "label": "Profile Id"
+        },
+        {
+          "key": "Filer",
+          "label": "Filer"
+        },
+        {
+          "label": "Person",
+          "key": "RegId",
+          "displayType": "person"
+        },
+        {
+          "key": "PublishStatus",
+          "label": "Publish Status"
+        },
+        {
+          "key": "DocumentType",
+          "label": "Document Type"
+        },
+        {
+          "key": "LastModifiedDate",
+          "label": "Last Modified Date",
+          "displayType": "date"
+        }
+      ],
+      "searchConfig": {
+        "directions": "Type a Employee ID or other info",
+        "label": "",
+        "placeholder": "Search for documents",
+        "indexName": "documents-demo"
+      },
+      "searchDaterangeConfig": {
+        "active": false,
+        "filterKey": "metadata.LastModifiedDate.raw",
+        "filterLabel": "Last Modified Date",
+        "showCalendar": true,
+        "showRelativeRange": true,
+        "placeholder": "Choose Date Range",
+        "displayRangeLabelInsteadOfDates": true,
+        "showDropdowns": true
+      },
+      "facetsConfig": {
+        "active": true,
+        "facets": {
+          "metadata.DocumentType.label.raw": {
+            "key": "metadata.DocumentType.label.raw",
+            "label": "Document Type",
+            "order": "asc",
+            "size": 5
+          },
+          "metadata.PublishStatus": {
+            "key": "metadata.PublishStatus.raw",
+            "label": "Publish Status",
+            "order": "asc",
+            "size": 10
+          },
+          "metadata.Filer": {
+            "key": "metadata.Filer.raw",
+            "label": "Filer",
+            "order": "asc",
+            "size": 10
+          }
+        }
+      },
+      "autocompleteConfig": {
+        "type": "personAutocomplete",
+        "filterKey": "metadata.RegId",
+        "filterLabel": "Employee"
+      }
+    },
+    "edit": {
+      "theme": "uw-default",
+      "pageName": "Edit Content Item",
+      "fieldsToDisplay": [
+        {
+          "key": "DataApiOptionLabel",
+          "label": "DataApiOption show label",
+          "required": false,
+          "disabled": true,
+          "displayType": "select",
+          "dynamicSelectConfig": {
+            "type": "test-type",
+            "labelPath": "label"
+          }
+        },
+        {
+          "key": "DataApiOptionCode",
+          "label": "DataApiOption Show Code",
+          "required": false,
+          "disabled": true,
+          "displayType": "select",
+          "dynamicSelectConfig": {
+            "type": "test-type",
+            "labelPath": "metadata.Code"
+          }
+        },
+        {
+          "key": "Filer",
+          "label": "Filer",
+          "required": true,
+          "disabled": true
+        },
+        {
+          "key": "DocumentType",
+          "label": "Document Type",
+          "disabled": true
+        },
+        {
+          "key": "PublishStatus",
+          "label": "Publish Status",
+          "required": true,
+          "disabled": true,
+          "displayType": "select",
+          "options": [
+            {
+              "value": ""
+            },
+            {
+              "value": "Draft"
+            },
+            {
+              "value": "Published"
+            }
+          ]
+        },
+        {
+          "key": "LastModifiedDate",
+          "label": "Last Modified Date",
+          "dataType": "date",
+          "displayType": "date",
+          "disabled": true
+        },
+        {
+          "key": "StudentId",
+          "label": "Student",
+          "displayType": "student-autocomplete",
+          "disabled": true
+        },
+        {
+          "key": "RegId",
+          "label": "Employee",
+          "displayType": "person-autocomplete",
+          "disabled": true
+        },
+        {
+          "key": "ReleaseDate",
+          "label": "Intake Date",
+          "displayType": "date",
+          "disabled": true
+        }
+      ],
+      "buttons": [
+        {
+          "label": "Void",
+          "command": "voidItem"
+        },
+        {
+          "label": "Publish",
+          "command": "publishItem"
+        },
+        {
+          "label": "Save",
+          "color": "primary",
+          "command": "saveItem"
+        }
+      ],
+      "viewPanel": true
+    },
+    "create": {
+      "theme": "uw-default",
+      "pageName": "Create Content Item",
+      "fieldsToDisplay": [
+        {
+          "key": "DataApiOptionLabel",
+          "label": "DataApiOption show label",
+          "required": true,
+          "displayType": "select",
+          "dynamicSelectConfig": {
+            "type": "test-type",
+            "labelPath": "label"
+          }
+        },
+        {
+          "key": "DataApiOptionCode",
+          "label": "DataApiOption Show Code",
+          "required": false,
+          "displayType": "select",
+          "dynamicSelectConfig": {
+            "type": "test-type",
+            "labelPath": "metadata.Code"
+          }
+        },
+        {
+          "key": "Filer",
+          "label": "Filer",
+          "required": true
+        },
+        {
+          "key": "PublishStatus",
+          "label": "Publish Status",
+          "displayType": "select",
+          "options": [
+            {
+              "value": ""
+            },
+            {
+              "value": "Draft"
+            },
+            {
+              "value": "Published"
+            }
+          ]
+        },
+        {
+          "key": "LastModifiedDate",
+          "label": "Last Modified Date",
+          "displayType": "date",
+          "required": true
+        },
+        {
+          "key": "StudentId",
+          "label": "Student",
+          "required": true,
+          "displayType": "student-autocomplete"
+        },
+        {
+          "key": "RegId",
+          "label": "Employee",
+          "required": true,
+          "displayType": "person-autocomplete"
+        }
+      ],
+      "buttons": [
+        {
+          "label": "Save",
+          "color": "primary",
+          "command": "saveItem"
+        },
+        {
+          "label": "Cancel",
+          "alwaysActive": true,
+          "command": "cancel"
+        }
+      ],
+      "viewPanel": true,
+      "uploadAnother": false
+    }
+  }
+}

--- a/e2e/mocks/profile-api/list.json
+++ b/e2e/mocks/profile-api/list.json
@@ -5,6 +5,9 @@
     },
     "demo2": {
       "href": "http://__current_host__:12345/profile/v1/app/my-app/demo2"
+    },
+    "demo3": {
+      "href": "http://__current_host__:12345/profile/v1/app/my-app/demo3"
     }
   }
 }

--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -14,6 +14,7 @@
               [attr.id]="'custom-input-'+ i"
             >
             </app-options-input>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
             <mat-error>
               {{getErrorMessage(fieldToDisplay.key)}}
             </mat-error>
@@ -36,6 +37,7 @@
               [id]="'custom-input-'+ i"
               [attr.id]="'custom-input-'+ i"
             ></app-checkbox-input>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
             <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
           </mat-form-field>
 
@@ -48,6 +50,7 @@
               [attr.id]="'custom-input-'+ i"
             >
             </app-student-autocomplete>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
             <mat-error>Please select a valid {{fieldToDisplay.label}}</mat-error>
           </mat-form-field>
 
@@ -60,6 +63,7 @@
               [attr.id]="'custom-input-'+ i"
             >
             </app-person-autocomplete>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
             <mat-error>Please select a valid {{fieldToDisplay.label}}</mat-error>
           </mat-form-field>
 
@@ -70,6 +74,7 @@
                    [attr.aria-label]="fieldToDisplay.label"
                    [required]="formGroup.get('metadata').get(fieldToDisplay.key).errors !== null && formGroup.get('metadata').get(fieldToDisplay.key).errors.required"
             >
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
             <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
           </mat-form-field>
         </div>

--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -14,7 +14,7 @@
               [attr.id]="'custom-input-'+ i"
             >
             </app-options-input>
-            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
             <mat-error>
               {{getErrorMessage(fieldToDisplay.key)}}
             </mat-error>
@@ -37,7 +37,7 @@
               [id]="'custom-input-'+ i"
               [attr.id]="'custom-input-'+ i"
             ></app-checkbox-input>
-            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
             <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
           </mat-form-field>
 
@@ -50,7 +50,7 @@
               [attr.id]="'custom-input-'+ i"
             >
             </app-student-autocomplete>
-            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
             <mat-error>Please select a valid {{fieldToDisplay.label}}</mat-error>
           </mat-form-field>
 
@@ -63,7 +63,7 @@
               [attr.id]="'custom-input-'+ i"
             >
             </app-person-autocomplete>
-            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
             <mat-error>Please select a valid {{fieldToDisplay.label}}</mat-error>
           </mat-form-field>
 
@@ -74,7 +74,7 @@
                    [attr.aria-label]="fieldToDisplay.label"
                    [required]="formGroup.get('metadata').get(fieldToDisplay.key).errors !== null && formGroup.get('metadata').get(fieldToDisplay.key).errors.required"
             >
-            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
+            <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
             <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
           </mat-form-field>
         </div>

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -9,6 +9,7 @@ import {
   MatCheckboxModule,
   MatDatepickerModule,
   MatFormFieldModule,
+  MatIconModule,
   MatInputModule,
   MatNativeDateModule,
   MatOptionModule,
@@ -60,7 +61,8 @@ describe('ContentMetadataComponent', () => {
         MatOptionModule,
         MatAutocompleteModule,
         MatSelectModule,
-        MatProgressSpinnerModule
+        MatProgressSpinnerModule,
+        MatIconModule
       ],
       declarations: [
         ContentMetadataComponent,

--- a/src/app/shared/widgets/timestamp-picker/timestamp-picker.component.html
+++ b/src/app/shared/widgets/timestamp-picker/timestamp-picker.component.html
@@ -12,7 +12,7 @@
          appElasticSearchDateValidator
   >
   <mat-datepicker-toggle *ngIf="!disabled" matSuffix [for]="picker"></mat-datepicker-toggle>
-  <mat-icon *ngIf="disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
+  <mat-icon *ngIf="disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
   <mat-datepicker #picker></mat-datepicker>
   <mat-error>
     <span

--- a/src/app/shared/widgets/timestamp-picker/timestamp-picker.component.html
+++ b/src/app/shared/widgets/timestamp-picker/timestamp-picker.component.html
@@ -11,7 +11,8 @@
          [attr.aria-required]="required"
          appElasticSearchDateValidator
   >
-  <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+  <mat-datepicker-toggle *ngIf="!disabled" matSuffix [for]="picker"></mat-datepicker-toggle>
+  <mat-icon *ngIf="disabled" matSuffix class="disabled-icon" matTooltip="Disabled">lock</mat-icon>
   <mat-datepicker #picker></mat-datepicker>
   <mat-error>
     <span

--- a/src/styles.css
+++ b/src/styles.css
@@ -88,7 +88,7 @@
 
 
 
-/*Increase disable field's text alpha from default to 0.5 */
+/*Increase disable field's text alpha from default to 0.55 */
 .uw-default .cs-content-page .mat-select-disabled .mat-select-value {
   color: rgba(0,0,0,.55);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,24 @@
     padding: 0rem 2rem;
 }
 
+
+
+/*Increase disable field's text alpha from default to 0.5 */
+.uw-default .cs-content-page .mat-select-disabled .mat-select-value {
+  color: rgba(0,0,0,.5);
+}
+.uw-default .cs-content-page :disabled  {
+  color: rgba(0,0,0,.5);
+}
+.uw-default .disabled-icon  {
+  color: rgba(0,0,0,.5);
+  font-size: smaller;
+  margin-left: 1rem;
+
+}
+
+
+
 .uw-default .cs-content-page .mat-raised-button {
     margin-right: 1rem;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -90,13 +90,13 @@
 
 /*Increase disable field's text alpha from default to 0.5 */
 .uw-default .cs-content-page .mat-select-disabled .mat-select-value {
-  color: rgba(0,0,0,.5);
+  color: rgba(0,0,0,.55);
 }
 .uw-default .cs-content-page :disabled  {
-  color: rgba(0,0,0,.5);
+  color: rgba(0,0,0,.55);
 }
 .uw-default .disabled-icon  {
-  color: rgba(0,0,0,.5);
+  color: rgba(0,0,0,.55);
   font-size: smaller;
   margin-left: 1rem;
 


### PR DESCRIPTION
CAB-3699: SFS/Procurement Disabled fields to be more readable  …

- add 'lock' icon next to disabled fields, with a tool tip 'Read-only' on edit-page
- increase the alpha for disabled fields & buttons from the default '0.38' to '0.55'