### PR TITLE
CAB-3773: Exec Office data-api is not sorting alphabetically

### DIFF
--- a/src/app/shared/providers/dataapivalue.service.ts
+++ b/src/app/shared/providers/dataapivalue.service.ts
@@ -18,7 +18,7 @@ export class DataApiValueService {
 
   @CacheObservableDecorator
   public listByType(type: string): Observable<DataApiValueSearchResults> {
-    const params = new HttpParams().set('size', this.DATA_API_VALUE_PAGE_SIZE);
+    const params = new HttpParams().set('size', this.DATA_API_VALUE_PAGE_SIZE).set('sortbys', '[{"field": "label"}]');
     const options = this.buildRequestOptions(params);
 
     return this.http.get<DataApiValueSearchResults>(this.valueUrl + '/' + type, options);
@@ -30,7 +30,7 @@ export class DataApiValueService {
     parentType: string,
     parentId: string
   ): Observable<DataApiValueSearchResults> {
-    const params = new HttpParams().set('size', this.DATA_API_VALUE_PAGE_SIZE);
+    const params = new HttpParams().set('size', this.DATA_API_VALUE_PAGE_SIZE).set('sortbys', '[{"field": "label"}]');
     const options = this.buildRequestOptions(params);
 
     return this.http.get<DataApiValueSearchResults>(

--- a/src/app/shared/providers/dataapivalue.service.ts
+++ b/src/app/shared/providers/dataapivalue.service.ts
@@ -18,7 +18,9 @@ export class DataApiValueService {
 
   @CacheObservableDecorator
   public listByType(type: string): Observable<DataApiValueSearchResults> {
-    const params = new HttpParams().set('size', this.DATA_API_VALUE_PAGE_SIZE).set('sortbys', '[{"field": "label"}]');
+    const params = new HttpParams()
+      .set('size', this.DATA_API_VALUE_PAGE_SIZE)
+      .set('sortbys', '[{"field": "order"},{"field": "label"}]');
     const options = this.buildRequestOptions(params);
 
     return this.http.get<DataApiValueSearchResults>(this.valueUrl + '/' + type, options);
@@ -30,7 +32,9 @@ export class DataApiValueService {
     parentType: string,
     parentId: string
   ): Observable<DataApiValueSearchResults> {
-    const params = new HttpParams().set('size', this.DATA_API_VALUE_PAGE_SIZE).set('sortbys', '[{"field": "label"}]');
+    const params = new HttpParams()
+      .set('size', this.DATA_API_VALUE_PAGE_SIZE)
+      .set('sortbys', '[{"field": "order"},{"field": "label"}]');
     const options = this.buildRequestOptions(params);
 
     return this.http.get<DataApiValueSearchResults>(


### PR DESCRIPTION
- add sortby label to data-api listByType & listByTypeAndParent