### PR TITLE
CAB-3844: Fixes intermittent unit test failures

### DIFF
--- a/src/app/content/create-page/create-page.component.spec.ts
+++ b/src/app/content/create-page/create-page.component.spec.ts
@@ -61,13 +61,11 @@ describe('CreatePageComponent', () => {
   let mockContentService: MockContentService;
   let mockUserService: MockUserService;
 
-  beforeEach(() => {
+  beforeEach(async(() => {
     activatedRoute = new ActivatedRouteStub();
     mockContentService = new MockContentService();
     mockUserService = new MockUserService();
-  });
 
-  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientModule,
@@ -118,7 +116,10 @@ describe('CreatePageComponent', () => {
       Object.assign(new Field(), { key: 'a', label: 'a' })
     ];
     createPageConfig.buttons = [saveButton];
-    createPageConfig.onSave = [{ key: 'PublishStatus', value: 'Published' }, { key: 'AnotherOnSave', value: 'Value' }];
+    createPageConfig.onSave = [
+      { key: 'PublishStatus', value: 'Published' },
+      { key: 'AnotherOnSave', value: 'Value' }
+    ];
     createPageConfig.pageName = 'test-create-page';
     createPageConfig.viewPanel = true;
 

--- a/src/app/content/edit-page/edit-page.component.spec.ts
+++ b/src/app/content/edit-page/edit-page.component.spec.ts
@@ -70,13 +70,11 @@ describe('EditPageComponent', () => {
   let mockUserService: MockUserService;
   let editPageConfig: ContentPageConfig;
 
-  beforeEach(() => {
+  beforeEach(async(() => {
     activatedRoute = new ActivatedRouteStub();
     mockContentService = new MockContentService();
     mockUserService = new MockUserService();
-  });
 
-  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientModule,

--- a/src/app/routing/shared/config-resolver.service.spec.ts
+++ b/src/app/routing/shared/config-resolver.service.spec.ts
@@ -38,7 +38,7 @@ describe('ConfigResolverService', () => {
         { provide: Router, useClass: RouterStub },
         NotificationService
       ]
-    });
+    }).compileComponents();
   }));
 
   let mockConfigService: MockConfigService;

--- a/src/app/search/display-search-page/display-search-page.component.spec.ts
+++ b/src/app/search/display-search-page/display-search-page.component.spec.ts
@@ -94,22 +94,22 @@ describe('DisplaySearchPageComponent', () => {
         NotificationService
       ],
       schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+    })
+      .compileComponents()
+      .then(() => {
+        activatedRoute.testParamMap = { page: 'test-page' };
+        activatedRoute.testQueryParamMap = { s: JSON.stringify(new SearchModel()) };
 
-  beforeEach(async(() => {
-    activatedRoute.testParamMap = { page: 'test-page' };
-    activatedRoute.testQueryParamMap = { s: JSON.stringify(new SearchModel()) };
+        const pageConfig = new SearchPageConfig();
+        pageConfig.pageName = 'test-page';
 
-    const pageConfig = new SearchPageConfig();
-    pageConfig.pageName = 'test-page';
+        const config = new Config();
+        config.tenant = 'test-tenant';
+        config.pages['test-page'] = pageConfig;
 
-    const config = new Config();
-    config.tenant = 'test-tenant';
-    config.pages['test-page'] = pageConfig;
-
-    console.log(JSON.stringify(config));
-    activatedRoute.testData = { config: config };
+        console.log(JSON.stringify(config));
+        activatedRoute.testData = { config: config };
+      });
   }));
 
   beforeEach(() => {

--- a/src/app/search/display-search-page/display-search-page.component.spec.ts
+++ b/src/app/search/display-search-page/display-search-page.component.spec.ts
@@ -63,16 +63,15 @@ class MockContentService {
 
 describe('DisplaySearchPageComponent', () => {
   let mockContentService: MockContentService;
-  beforeEach(() => {
+
+  beforeEach(async(() => {
     mockContentService = new MockContentService();
     activatedRoute = new ActivatedRouteStub();
     searchServiceSpy = new MockSearchService();
     dataService = new DataService();
     dataService.set('adjacentIds', ['123', '456']);
     studentService = new StudentService(null, null);
-  });
 
-  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,

--- a/src/app/search/search-page/search-page.component.spec.ts
+++ b/src/app/search/search-page/search-page.component.spec.ts
@@ -36,15 +36,13 @@ class MockSearchService {
 }
 
 describe('SearchPageComponent', () => {
-  beforeEach(() => {
+  beforeEach(async(() => {
     activatedRoute = new ActivatedRouteStub();
     searchServiceSpy = new MockSearchService();
     dataService = new DataService();
     dataService.set('adjacentIds', ['123', '456']);
     studentService = new StudentService(null, null);
-  });
 
-  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, MaterialConfigModule, HttpClientModule, RouterTestingModule],
       declarations: [SearchPageComponent, SearchBoxComponent, SearchResultsComponent],

--- a/src/app/search/search-page/search-page.component.spec.ts
+++ b/src/app/search/search-page/search-page.component.spec.ts
@@ -58,21 +58,21 @@ describe('SearchPageComponent', () => {
         NotificationService
       ],
       schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+    })
+      .compileComponents()
+      .then(() => {
+        activatedRoute.testParamMap = { page: 'test-page' };
 
-  beforeEach(async(() => {
-    activatedRoute.testParamMap = { page: 'test-page' };
+        const pageConfig = new SearchPageConfig();
+        pageConfig.pageName = 'test-page';
 
-    const pageConfig = new SearchPageConfig();
-    pageConfig.pageName = 'test-page';
+        const config = new Config();
+        config.tenant = 'test-tenant';
+        config.pages['test-page'] = pageConfig;
 
-    const config = new Config();
-    config.tenant = 'test-tenant';
-    config.pages['test-page'] = pageConfig;
-
-    console.log(JSON.stringify(config));
-    activatedRoute.testData = { config: config };
+        console.log(JSON.stringify(config));
+        activatedRoute.testData = { config: config };
+      });
   }));
 
   beforeEach(() => {

--- a/src/app/shared/widgets/header/header.component.spec.ts
+++ b/src/app/shared/widgets/header/header.component.spec.ts
@@ -32,12 +32,10 @@ describe('HeaderComponent', () => {
   let activatedRoute: ActivatedRouteStub;
   let configServiceStub: ConfigServiceStub;
 
-  beforeEach(() => {
+  beforeEach(async(() => {
     activatedRoute = new ActivatedRouteStub();
     configServiceStub = new ConfigServiceStub();
-  });
 
-  beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [MaterialConfigModule, HttpClientModule, NoopAnimationsModule],
       declarations: [HeaderComponent],

--- a/src/app/shared/widgets/header/header.component.spec.ts
+++ b/src/app/shared/widgets/header/header.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, inject, TestBed } from '@angular/core/testing';
+import { Observable, of } from 'rxjs';
 
 import { HeaderComponent } from './header.component';
 import { MaterialConfigModule } from '../../../routing/material-config.module';
@@ -13,6 +14,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ProgressService } from '../../providers/progress.service';
 import { NotificationService } from '../../providers/notification.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { User } from '../../../user/shared/user';
 
 class RouterStub {
   navigate(url: string) {
@@ -23,6 +25,16 @@ class RouterStub {
 class ConfigServiceStub {
   getTenantList(): Promise<string[]> {
     return Promise.resolve(Array.from(['demo', 'one', 'two', 'three']));
+  }
+}
+
+class MockUserService extends UserService {
+  constructor() {
+    super(null, null, null);
+  }
+
+  getUserObservable(): Observable<User> {
+    return of(new User('testUser'));
   }
 }
 
@@ -43,10 +55,10 @@ describe('HeaderComponent', () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useClass: RouterStub },
         { provide: ConfigService, useValue: configServiceStub },
+        { provide: UserService, useValue: new MockUserService() },
         ConfigResolver,
         GlobalEventsManagerService,
         ProgressService,
-        UserService,
         NotificationService
       ],
       schemas: [NO_ERRORS_SCHEMA]

--- a/src/app/user/shared/user.service.spec.ts
+++ b/src/app/user/shared/user.service.spec.ts
@@ -1,4 +1,4 @@
-import { inject, TestBed } from '@angular/core/testing';
+import { inject, TestBed, async } from '@angular/core/testing';
 
 import { UserService } from './user.service';
 import { User } from './user';
@@ -25,9 +25,8 @@ describe('UserService', () => {
     expect(service).toBeTruthy();
   }));
 
-  it('should return a user named myusername', inject(
-    [UserService, HttpClient],
-    (service: UserService, http: HttpClient) => {
+  it('should return a user named myusername', async(
+    inject([UserService, HttpClient], (service: UserService, http: HttpClient) => {
       const httpSpy = spyOn(http, 'get').and.callFake(function(_url, _options) {
         return of({
           userName: 'myusername',
@@ -42,6 +41,6 @@ describe('UserService', () => {
         expect(authenticatedUser.userName).toBe('myusername');
         expect(authenticatedUser.userGroups).toEqual(['test-group']);
       });
-    }
+    })
   ));
 });


### PR DESCRIPTION
This pull request deals with errors of the form:
`No component factory found for NotificationComponent`

As far as I can tell, the underlying issue, is that whenever a component calls NotificationService.error(), the service internally calls:
`this.snackBar.openFromComponent(NotificationComponent, config);`

Notice that the NotificationComponent class is passed as a parameter. When running unit tests, the call to configureTestingModule may provide the required NotificationService type, but does not add the NotificationComponent to the list of declarations. Which makes _some_ sense because the unit tests are not expecting the component under test to call NotificationService.error().

The culprit seems to be the HeaderComponent that uses the UserService (which internally uses the NotificationService). The tests for HeaderComponent were not properly set up to use a MockUserService, instead they used a real UserService, which at some point in the future would fail to get a User, then try to use the NotificationService to report the error, only to have it fail when the internals of the NotificationService could not get a hold of the NotificationComponent.

Note: This pull request also contains these changes:
- UserService was relying on an observable but was not marked as an async test. I don't believe this caused the problem because this test properly mocked its required services.
- There were some tests that had 2 beforeEach(async). I believe the recommendation is to only have 1 beforeEach(async)
- All tests where standardized so that they start with a beforeEach(async), followed by any number of the regular beforeEach.