### PR TITLE
Locks rxjs-tslint-rules package to 4.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "@types/jasminewd2": "~2.0.8",
     "@types/node": "~12.12.21",
     "axe-webdriverjs": "^2.2.0",
-    "husky": "^3.1.0",
     "codelyzer": "^5.2.0",
+    "husky": "^3.1.0",
     "jasmine-core": "^3.5.0",
     "jasmine-reporters": "^2.3.2",
     "jasmine-spec-reporter": "^4.2.1",
@@ -90,7 +90,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "protractor": "^5.4.2",
-    "rxjs-tslint-rules": "^4.28.0",
+    "rxjs-tslint-rules": "4.27.1",
     "ts-node": "^8.2.0",
     "tslint": "~5.20.1",
     "typescript": "~3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6630,15 +6630,15 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs-tslint-rules@^4.28.0:
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/rxjs-tslint-rules/-/rxjs-tslint-rules-4.28.0.tgz#5e98a85008e58cce3e3af8906a87ddd8a98982cd"
-  integrity sha512-Nx0so6Iyc5+tyIgKRAh3wlBDMuKQ7V8PM/i1VauUYCEcvtKDvnQn542A2GNKJDmq/urVzaC8EXONlggONPjcsg==
+rxjs-tslint-rules@4.27.1:
+  version "4.27.1"
+  resolved "https://registry.yarnpkg.com/rxjs-tslint-rules/-/rxjs-tslint-rules-4.27.1.tgz#9f646ba2f768672bfdc4b51fc0e6c1a062412db1"
+  integrity sha512-LMTT0QeGKqBI+oOcWhnKTclovHFL9NrzviNeDc+iPRJpNsvq8ZN/nBaWAhFhnNtqMLX2SgWrhCKJcW6lAyxAYA==
   dependencies:
     "@phenomnomnominal/tsquery" "^4.0.0"
     decamelize "^3.0.0"
     resolve "^1.4.0"
-    semver "^7.0.0"
+    semver "^6.0.0"
     tslib "^1.8.0"
     tsutils "^3.0.0"
     tsutils-etc "^1.1.0"
@@ -6795,11 +6795,6 @@ semver@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.0.tgz#e95dc415d45ecf03f2f9f83b264a6b11f49c0cca"
   integrity sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==
-
-semver@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
-  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
This works around a change in transitive dependency (semver package) that was updated to a version that no longer supports Node v8.

Created CAB-3856 to revert the lock if we find it necessary after we move to a more recent Node version.

Commit that introduced the change: 103e20b1891d05ce86d8c49ed7f84407647d8b70 build(deps-dev): bump rxjs-tslint-rules from 4.27.1 to 4.28.0

rxjs-tslint-rules updates the version of semver to ^7.0.0 and starting from that version, semver no longer supports Node8. See:
- https://github.com/cartant/rxjs-tslint-rules/compare/v4.27.1...v4.28.0
- https://github.com/npm/node-semver/compare/v6.3.0...v7.1.1
