### PR TITLE
Adds an aria-label to the mat-select component so that it displays the currently selected value when the select box is displayed.

### DIFF
--- a/src/app/shared/widgets/options-input/options-input.component.html
+++ b/src/app/shared/widgets/options-input/options-input.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="formGroup">
-  <mat-select [formControlName]="internalFieldName" (selectionChange)="onSelect($event)">
+  <mat-select [formControlName]="internalFieldName" [aria-label]="ngControl?.value" (selectionChange)="onSelect($event)">
     <mat-option *ngFor="let option of this.options$| async" [value]="option.value">
       {{ option.displayValue }}
     </mat-option>

--- a/src/app/shared/widgets/options-input/options-input.component.spec.ts
+++ b/src/app/shared/widgets/options-input/options-input.component.spec.ts
@@ -1,4 +1,7 @@
+import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { OptionsInputComponent } from './options-input.component';
 import { FieldOption } from '../../../core/shared/model/field/field-option';
 import { Field } from '../../../core/shared/model/field';
@@ -56,4 +59,58 @@ describe('OptionsInputComponent', () => {
       expect(options[1].displayValue).toBe('val2');
     });
   });
+});
+
+@Component({
+  template: `
+    <div [formGroup]="formGroup">
+      <app-options-input
+        [formControlName]="'testFormControlName'"
+        [fieldConfig]="field"
+        [parentControl]="formGroup"
+        [id]="'test-custom-input'"
+      >
+      </app-options-input>
+    </div>
+  `
+})
+class TestHostComponent {
+  public field: Field;
+  public formGroup: FormGroup;
+
+  constructor() {
+    this.field = new Field();
+    this.field.options = [new FieldOption('optionOneValue', 'optionOneDisplayValue')];
+    this.formGroup = new FormGroup({
+      testFormControlName: new FormControl(this.field.options[0].value)
+    });
+  }
+}
+
+describe('OptionsInputComponent with host', () => {
+  let componentElement: HTMLElement;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async(() => {
+    const dataApiValueServiceSpy = jasmine.createSpyObj('DataApiValueService', ['listByType']);
+    TestBed.configureTestingModule({
+      imports: [SharedModule, NoopAnimationsModule, ReactiveFormsModule],
+      declarations: [TestHostComponent],
+      providers: [{ provide: DataApiValueService, useValue: dataApiValueServiceSpy }]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    componentElement = fixture.debugElement.queryAll(By.css('mat-select'))[0].nativeElement;
+
+    fixture.detectChanges();
+  });
+
+  it('should render aria-label attribute set to its option value', async(() => {
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(componentElement.getAttribute('aria-label')).toEqual('optionOneValue');
+    });
+  }));
 });


### PR DESCRIPTION
Fixes CAB-3803 (Selected value in drop downs not read by screen reader).

This change ONLY addresses the screen reader announcing the currently selected value of the dropdown. Interacting with the mat-select component with a screen reader is still a problem due to https://github.com/angular/components/issues/11083.