### PR TITLE
Prepends the label of the select component as part of the aria-label.

### DIFF
--- a/src/app/shared/widgets/options-input/options-input.component.html
+++ b/src/app/shared/widgets/options-input/options-input.component.html
@@ -1,5 +1,6 @@
 <div [formGroup]="formGroup">
-  <mat-select [formControlName]="internalFieldName" [aria-label]="ngControl?.value" (selectionChange)="onSelect($event)">
+  <mat-select [formControlName]="internalFieldName" [aria-label]="placeholder + ' ' + ngControl?.value"
+    (selectionChange)="onSelect($event)">
     <mat-option *ngFor="let option of this.options$| async" [value]="option.value">
       {{ option.displayValue }}
     </mat-option>

--- a/src/app/shared/widgets/options-input/options-input.component.spec.ts
+++ b/src/app/shared/widgets/options-input/options-input.component.spec.ts
@@ -65,6 +65,7 @@ describe('OptionsInputComponent', () => {
   template: `
     <div [formGroup]="formGroup">
       <app-options-input
+        [placeholder]="'testPlaceHolder'"
         [formControlName]="'testFormControlName'"
         [fieldConfig]="field"
         [parentControl]="formGroup"
@@ -107,10 +108,10 @@ describe('OptionsInputComponent with host', () => {
     fixture.detectChanges();
   });
 
-  it('should render aria-label attribute set to its option value', async(() => {
+  it('should render aria-label attribute set to its label and option value', async(() => {
     fixture.whenStable().then(() => {
       fixture.detectChanges();
-      expect(componentElement.getAttribute('aria-label')).toEqual('optionOneValue');
+      expect(componentElement.getAttribute('aria-label')).toEqual('testPlaceHolder optionOneValue');
     });
   }));
 });


### PR DESCRIPTION
Fixes CAB-3803.

According to WC3, the aria-label attribute is meant to read the label of the listbox. With commit 35bae7ff1459147ad94affa028119517fc1b6b71, the aria-label was changed to read the selected option's value, which is not what this attribute is meant to be used for. This commit changes the aria-label to first display the standard label name, and then appends the selected option value. Even though it is not standard to use this attribute to read the selected value, it is meant to mitigate the problem with mat-select where the selected option is not read at all.