### PR TITLE
Adds ability to start dev server with a proxy setup for each service.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ Thumbs.db
 
 # Env files
 /src/environments/environment.*.ts
+/src/environment/*.json
 start.sh

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Stop the containers when you are done with:
 yarn stop-mock-services
 ```
 
+## Development server with backend services hosted in AWS EC2
+
+- Install and configure the [AWS CLI](https://aws.amazon.com/cli/).
+- Install and configure the [AWS helper scripts](https://github.com/uw-it-edm/technical-operations/tree/master/aws-helper-scripts).
+- Setup the environment variables as described in the [EDM Data](https://github.com/uw-it-edm/workstation-setup/tree/master/configuration/edm-team) workstation setup. 
+- Login to AWS with 'developer' role.
+- Run SSH to tunnel requests to the app servers:
+```
+ec2TunnelToEnvAndType -p $EDM_PROFILE_API_PORT,$EDM_CONTENT_API_PORT,$EDM_SEARCH_API_PORT,$EDM_DATA_API_PORT dev apps
+```
+- Run Angular with the proxy setup for the remote servers (this is needed to by-pass CORS):
+```
+yarn start-localproxy
+```
+- Navigate to http://localhost:42000 watch the console to if there are any errors on the proxy url re-writting.
+
+How it works? There is a script (`./src/environments/replace-vars.mjs`) that will inject values from environment variables into the appropiate local files that includes your NetID used to make requests to back end servers and all the port numbers.
+
 ## Debug in VSCode
 - Add the following configuration to your launch.json file:
 ```

--- a/angular.json
+++ b/angular.json
@@ -43,6 +43,14 @@
                 }
               ]
             },
+            "localproxy": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.proxy.ts"
+                }
+              ]
+            },
             "travis": {
               "optimization": true,
               "outputHashing": "all",
@@ -87,6 +95,10 @@
           "configurations": {
             "local": {
               "browserTarget": "content-services-ui:build:local"
+            },
+            "localproxy": {
+              "browserTarget": "content-services-ui:build:localproxy",
+              "proxyConfig": "src/environments/local-proxy.conf.json"
             },
             "localmock": {
               "browserTarget": "content-services-ui:build:localmock"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "replace-vars": "ts-node ./src/environments/replace-vars.mjs",
     "start-local": "ng serve --configuration=local --disable-host-check",
+    "start-localproxy": "yarn replace-vars && ng serve --configuration=localproxy --disable-host-check",
     "start-localmock": "ng serve --configuration=localmock --disable-host-check",
     "build": "ng build",
     "test": "ng test --watch=false --sourceMap=false",

--- a/src/environments/environment.proxy.template.ts
+++ b/src/environments/environment.proxy.template.ts
@@ -1,0 +1,50 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --configuration=prod` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in `.angular-cli.json`.
+
+const netId = 'EDM_NETID';
+
+export const environment = {
+  production: false,
+
+  enableRouterTracing: false,
+
+  GATracking: 'fakeCode',
+
+  supportEmail: 'support@somedomain.com',
+
+  tenantConfigGithubPath: '/uw-it-edm/content-services-ui-config/contents/dev',
+
+  testUser: netId,
+
+  search_api: {
+    url: '/search-api',
+    context: '/search/v1/',
+    method: 'POST',
+    authenticationHeader: 'x-uw-act-as',
+    headers: { 'x-uw-act-as': netId }
+  },
+  content_api: {
+    url: '/content-api',
+    contextV3: '/content/v3',
+    contextV4: '/content/v4',
+    authenticationHeader: 'x-uw-act-as',
+    headers: { 'x-uw-act-as': netId }
+  },
+  profile_api: {
+    url: '/profile-api',
+    context: '/profile/v1',
+    app_name: 'content-services-ui',
+    authenticationHeader: 'x-uw-act-as',
+    headers: { 'x-uw-act-as': netId }
+  },
+  data_api: {
+    url: '/data-api',
+    studentContext: '/students/v1',
+    personContext: '/person/v1',
+    valueContext: '/v1/value',
+    authenticationHeader: 'x-uw-act-as',
+    headers: { 'x-uw-act-as': netId }
+  }
+};

--- a/src/environments/local-proxy.conf.template.json
+++ b/src/environments/local-proxy.conf.template.json
@@ -1,0 +1,38 @@
+{
+  "/profile-api/*": {
+    "target": "http://localhost:EDM_PROFILE_API_PORT",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/profile-api": ""
+    }
+  },
+  "/search-api/*": {
+    "target": "http://localhost:EDM_SEARCH_API_PORT",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/search-api": ""
+    }
+  },
+  "/content-api/*": {
+    "target": "http://localhost:EDM_CONTENT_API_PORT",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/content-api": ""
+    }
+  },
+  "/data-api/*": {
+    "target": "http://localhost:EDM_DATA_API_PORT",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/data-api": ""
+    }
+  }
+}

--- a/src/environments/replace-vars.mjs
+++ b/src/environments/replace-vars.mjs
@@ -1,0 +1,45 @@
+import { readFile, writeFile } from 'fs';
+
+const files = [
+  './src/environments/environment.proxy.template.ts',
+  './src/environments/local-proxy.conf.template.json'
+];
+const vars = {
+  'EDM_NETID': process.env.EDM_NETID,
+  'EDM_PROFILE_API_PORT': process.env.EDM_PROFILE_API_PORT,
+  'EDM_SEARCH_API_PORT': process.env.EDM_SEARCH_API_PORT,
+  'EDM_CONTENT_API_PORT': process.env.EDM_CONTENT_API_PORT,
+  'EDM_DATA_API_PORT': process.env.EDM_DATA_API_PORT
+};
+
+files.forEach(function (filePath) {
+  injectVarsInFile(filePath, function (err, newFilePath) {
+    if (err) {
+      console.error(`Error injecting environment variables to file ${filePath}.`, err);
+    } else {
+      console.log(`Injected environment variables from '${filePath}' to '${newFilePath}'`);
+    }
+  });
+});
+
+function injectVarsInFile(filePath, callback) {
+  readFile(filePath, 'utf8', (readError, data) => {
+    if (readError) {
+      callback(readError);
+      return;
+    }
+
+    Object.keys(vars).forEach(key => {
+      data = data.replace(key, vars[key]);
+    });
+
+    const newFileName = filePath.replace('.template', '');
+    writeFile(newFileName, data, 'utf8', (writeError) => {
+      if (writeError) {
+        callback(writeError);
+      } else {
+        callback(null, newFileName);
+      }
+    });
+  });
+}


### PR DESCRIPTION
High level changes:
- There is a script that can injects values from environment variables into configuration files.
- When 'yarn start-localproxy' is run an environment.proxy.ts file is created that has all paths to API's marked as relative (it also has your netId from environment variable).
- A 'local-proxy.conf.json' file is also created that maps all the relative API's to a localhost address with the port taken from environment variables. These are marked with 'changeOrigin=true' to bypass CORS.
