### PR TITLE
Updates to allow running tunneling server with Node 9 or above.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ yarn stop-mock-services
 ## Development server with backend services hosted in AWS EC2
 
 - **Important: Tunneling to the data-api does not work currently.**
-- Make sure you have Node v13.
+- Make sure you have Node v9.
 - Install and configure the [AWS CLI](https://aws.amazon.com/cli/).
 - Install and configure the [AWS helper scripts](https://github.com/uw-it-edm/technical-operations/tree/master/aws-helper-scripts).
 - Setup the environment variables as described in the [EDM Data](https://github.com/uw-it-edm/workstation-setup/tree/master/configuration/edm-team) workstation setup. 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "replace-vars": "ts-node ./src/environments/replace-vars.mjs",
+    "replace-vars": "node --experimental-modules ./src/environments/replace-vars.mjs",
     "start-local": "ng serve --configuration=local --disable-host-check",
     "start-travis": "ng serve --configuration=travis --disable-host-check",
     "start-localproxy": "yarn replace-vars && ng serve --configuration=localproxy --disable-host-check",


### PR DESCRIPTION
Fixes CAB-3887