### PR TITLE
Adds default left or right justification to cells of search page depending on the displayType.

### DIFF
--- a/src/app/core/shared/model/field.ts
+++ b/src/app/core/shared/model/field.ts
@@ -6,6 +6,12 @@ import { CourseConfig } from './field/course-config';
 export type FieldDataType = 'string' | 'number' | 'date' ;
 export type FieldDisplayType = 'date' | 'dateTime' | 'number' | 'currency' | 'student' | 'person' | 'select';
 
+export const isFieldRightAligned = (field: Field): boolean => {
+  const displayType = field && field.displayType;
+
+  return displayType && (displayType === 'currency' || displayType === 'number' || displayType === 'date' || displayType === 'dateTime');
+};
+
 export class Field {
   public key: string;
   public label: string;

--- a/src/app/core/shared/model/field.ts
+++ b/src/app/core/shared/model/field.ts
@@ -4,7 +4,7 @@ import { DynamicSelectConfig } from './field/dynamic-select-config';
 import { CourseConfig } from './field/course-config';
 
 export type FieldDataType = 'string' | 'number' | 'date' ;
-export type FieldDisplayType = 'date' | 'dateTime' | 'currency' | 'student' | 'person' | 'select';
+export type FieldDisplayType = 'date' | 'dateTime' | 'number' | 'currency' | 'student' | 'person' | 'select';
 
 export class Field {
   public key: string;

--- a/src/app/search/search-results/search-results.component.css
+++ b/src/app/search/search-results/search-results.component.css
@@ -1,16 +1,20 @@
-.cell-type-date,
-.cell-type-dateTime,
-.cell-type-currency,
-.cell-type-number {
+.cell-align-right {
   /* Right align the content of header and row cells */
   justify-content: flex-end;
 }
 
-.mat-header-cell.cell-type-date > div,
-.mat-header-cell.cell-type-dateTime > div,
-.mat-header-cell.cell-type-currency > div,
-.mat-header-cell.cell-type-number > div {
-  /* Padding of right aligned header content so that it doesn't collide with the next header.
+.mat-header-cell .header-cell-content {
+  /* Align text to the left by default, this is needed because the sortable header is rendered
+     as a button, which by default centers its text. */
+  text-align: left;
+}
+
+.mat-header-cell.cell-align-right .header-cell-content {
+  text-align: right;
+}
+
+.mat-header-cell.cell-align-right > .header-cell-content {
+  /* This rule applies for the non-sortable header.
      Note: The reason why is 18px is because it matches the width of the up/down sorting arrow so sortable
            and non-sortable fields will have the same padding. */
   padding-right: 18px;

--- a/src/app/search/search-results/search-results.component.css
+++ b/src/app/search/search-results/search-results.component.css
@@ -1,3 +1,17 @@
-.cs-search-table-cell {
-  padding-right: 10px;
+.cell-type-date,
+.cell-type-dateTime,
+.cell-type-currency,
+.cell-type-number {
+  /* Right align the content of header and row cells */
+  justify-content: flex-end;
+}
+
+.mat-header-cell.cell-type-date > div,
+.mat-header-cell.cell-type-dateTime > div,
+.mat-header-cell.cell-type-currency > div,
+.mat-header-cell.cell-type-number > div {
+  /* Padding of right aligned header content so that it doesn't collide with the next header.
+     Note: The reason why is 18px is because it matches the width of the up/down sorting arrow so sortable
+           and non-sortable fields will have the same padding. */
+  padding-right: 18px;
 }

--- a/src/app/search/search-results/search-results.component.html
+++ b/src/app/search/search-results/search-results.component.html
@@ -32,14 +32,18 @@
     <ng-container *ngFor="let col of pageConfig.fieldsToDisplay" matColumnDef={{col.key}}>
       <span [ngSwitch]="col.sortable">
          <span *ngSwitchCase="false">
-          <mat-header-cell *matHeaderCellDef>{{ col.label }}</mat-header-cell>
+          <mat-header-cell *matHeaderCellDef [ngClass]="getCellCssClass(col)">
+            <div>{{ col.label }}</div>
+          </mat-header-cell>
         </span>
         <span *ngSwitchDefault>
-         <mat-header-cell *matHeaderCellDef mat-sort-header>{{ col.label }}</mat-header-cell>
+         <mat-header-cell *matHeaderCellDef mat-sort-header [ngClass]="getCellCssClass(col)">
+           <div>{{ col.label }}</div>
+          </mat-header-cell>
         </span>
       </span>
 
-      <mat-cell *matCellDef="let element" class="cs-search-table-cell">
+      <mat-cell *matCellDef="let element" [ngClass]="getCellCssClass(col)">
         <app-display-field [field]="col"
                            [value]="getValueFromMetadata(element.metadata,col.key)"></app-display-field>
       </mat-cell>

--- a/src/app/search/search-results/search-results.component.html
+++ b/src/app/search/search-results/search-results.component.html
@@ -32,18 +32,18 @@
     <ng-container *ngFor="let col of pageConfig.fieldsToDisplay" matColumnDef={{col.key}}>
       <span [ngSwitch]="col.sortable">
          <span *ngSwitchCase="false">
-          <mat-header-cell *matHeaderCellDef [ngClass]="getCellCssClass(col)">
-            <div>{{ col.label }}</div>
+          <mat-header-cell *matHeaderCellDef [ngClass]="{ 'cell-align-right': isFieldRightAligned(col)}">
+            <div class="header-cell-content">{{ col.label }}</div>
           </mat-header-cell>
         </span>
         <span *ngSwitchDefault>
-         <mat-header-cell *matHeaderCellDef mat-sort-header [ngClass]="getCellCssClass(col)">
-           <div>{{ col.label }}</div>
+         <mat-header-cell *matHeaderCellDef mat-sort-header [ngClass]="{ 'cell-align-right': isFieldRightAligned(col)}">
+           <div class="header-cell-content">{{ col.label }}</div>
           </mat-header-cell>
         </span>
       </span>
 
-      <mat-cell *matCellDef="let element" [ngClass]="getCellCssClass(col)">
+      <mat-cell *matCellDef="let element" [ngClass]="{ 'cell-align-right': isFieldRightAligned(col)}">
         <app-display-field [field]="col"
                            [value]="getValueFromMetadata(element.metadata,col.key)"></app-display-field>
       </mat-cell>

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -14,6 +14,7 @@ import { takeUntil } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { ObjectUtilities } from '../../core/util/object-utilities';
+import { Field } from '../../core/shared/model/field';
 
 @Component({
   selector: 'app-search-results',
@@ -168,6 +169,10 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
 
   getValueFromMetadata(metadata, key: string) {
     return ObjectUtilities.getNestedObjectFromStringPath(metadata, key);
+  }
+
+  getCellCssClass(field: Field): string {
+    return field && field.displayType && `cell-type-${field.displayType}`;
   }
 
   onPageEvent(pageEvent: PageEvent) {

--- a/src/app/search/search-results/search-results.component.ts
+++ b/src/app/search/search-results/search-results.component.ts
@@ -14,7 +14,7 @@ import { takeUntil } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { ObjectUtilities } from '../../core/util/object-utilities';
-import { Field } from '../../core/shared/model/field';
+import { Field, isFieldRightAligned } from '../../core/shared/model/field';
 
 @Component({
   selector: 'app-search-results',
@@ -171,8 +171,8 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
     return ObjectUtilities.getNestedObjectFromStringPath(metadata, key);
   }
 
-  getCellCssClass(field: Field): string {
-    return field && field.displayType && `cell-type-${field.displayType}`;
+  isFieldRightAligned(field: Field): boolean {
+    return isFieldRightAligned(field);
   }
 
   onPageEvent(pageEvent: PageEvent) {

--- a/src/app/shared/widgets/display-field/display-field.component.css
+++ b/src/app/shared/widgets/display-field/display-field.component.css
@@ -1,12 +1,9 @@
-.field-cell {
+.field-content {
   /* Padding of left aligned row cell. */
   padding-right: 10px;
 }
 
-.field-cell.field-type-date,
-.field-cell.field-type-dateTime,
-.field-cell.field-type-number,
-.field-cell.field-type-currency {
+.field-content.field-align-right {
   /* Padding of right aligned row cell (matches the header cell padding). */
   padding-right: 18px;
 }

--- a/src/app/shared/widgets/display-field/display-field.component.css
+++ b/src/app/shared/widgets/display-field/display-field.component.css
@@ -1,0 +1,12 @@
+.field-cell {
+  /* Padding of left aligned row cell. */
+  padding-right: 10px;
+}
+
+.field-cell.field-type-date,
+.field-cell.field-type-dateTime,
+.field-cell.field-type-number,
+.field-cell.field-type-currency {
+  /* Padding of right aligned row cell (matches the header cell padding). */
+  padding-right: 18px;
+}

--- a/src/app/shared/widgets/display-field/display-field.component.html
+++ b/src/app/shared/widgets/display-field/display-field.component.html
@@ -1,20 +1,18 @@
-<span *ngIf="field" [ngSwitch]="getFieldType()">
- <span *ngSwitchCase="'date'">
+<div *ngIf="field" [ngSwitch]="getFieldDisplayType()" [ngClass]="['field-cell', 'field-type-' + getFieldDisplayType()]">
+  <span *ngSwitchCase="'date'">
   {{value | date: 'M/d/yyyy'}}
   </span>
   <span *ngSwitchCase="'dateTime'">
-     {{value | date: 'M/d/yyyy, h:mm a' }}
-   </span>
-   <span *ngSwitchCase="'currency'">
+    {{value | date: 'M/d/yyyy, h:mm a' }}
+  </span>
+  <span *ngSwitchCase="'currency'">
     {{value | safeCurrency }}
   </span>
   <span *ngSwitchCase="'student'">
-    <app-student-display
-      value="{{value}}"></app-student-display>
+    <app-student-display value="{{value}}"></app-student-display>
   </span>
   <span *ngSwitchCase="'person'">
-    <app-person-display
-      value="{{value}}"></app-person-display>
+    <app-person-display value="{{value}}"></app-person-display>
   </span>
   <span *ngSwitchCase="'dataApiValue'">
     <app-data-api-display
@@ -26,4 +24,4 @@
   <span *ngSwitchDefault>
    {{value}}
   </span>
-</span>
+</div>

--- a/src/app/shared/widgets/display-field/display-field.component.html
+++ b/src/app/shared/widgets/display-field/display-field.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="field" [ngSwitch]="getFieldDisplayType()" [ngClass]="['field-cell', 'field-type-' + getFieldDisplayType()]">
+<div *ngIf="field" [ngSwitch]="getFieldDisplayType()" [ngClass]="{ 'field-content': true, 'field-align-right': isRightAligned }">
   <span *ngSwitchCase="'date'">
   {{value | date: 'M/d/yyyy'}}
   </span>

--- a/src/app/shared/widgets/display-field/display-field.component.spec.ts
+++ b/src/app/shared/widgets/display-field/display-field.component.spec.ts
@@ -33,7 +33,7 @@ describe('DisplayFieldComponent', () => {
 
     fixture.detectChanges();
 
-    const span = fixture.debugElement.query(By.css('span span'));
+    const span = fixture.debugElement.query(By.css('div span'));
     const el = span.nativeElement;
 
     expect(el.innerHTML.trim()).toBe('11/21/2017');
@@ -47,7 +47,7 @@ describe('DisplayFieldComponent', () => {
 
     fixture.detectChanges();
 
-    const span = fixture.debugElement.query(By.css('span span'));
+    const span = fixture.debugElement.query(By.css('div span'));
     const el = span.nativeElement;
 
     expect(el.innerHTML.trim()).toBe('12/17/1995, 3:24 AM');
@@ -74,7 +74,7 @@ describe('DisplayFieldComponent', () => {
 
     fixture.detectChanges();
 
-    const span = fixture.debugElement.query(By.css('span span'));
+    const span = fixture.debugElement.query(By.css('div span'));
     const el = span.nativeElement;
 
     expect(el.innerHTML.trim()).toBe('1511292577000');
@@ -102,7 +102,7 @@ describe('DisplayFieldComponent', () => {
 
       fixture.detectChanges();
 
-      const span = fixture.debugElement.query(By.css('span span'));
+      const span = fixture.debugElement.query(By.css('div span'));
       const el = span.nativeElement;
 
       expect(el.innerHTML.trim()).toBe(expectedString);

--- a/src/app/shared/widgets/display-field/display-field.component.ts
+++ b/src/app/shared/widgets/display-field/display-field.component.ts
@@ -10,24 +10,14 @@ export class DisplayFieldComponent {
   @Input() field: Field;
   @Input() value;
 
-  constructor() {}
-
-  getFieldType(): string {
+  getFieldDisplayType(): string {
     let type = 'default';
 
-    if (this.field) {
-      if (this.field.displayType === 'date') {
-        type = 'date';
-      } else if (this.field.displayType === 'dateTime') {
-        type = 'dateTime';
-      } else if (this.field.displayType === 'currency') {
-        type = 'currency';
-      } else if (this.field.displayType === 'student') {
-        type = 'student';
-      } else if (this.field.displayType === 'person') {
-        type = 'person';
-      } else if (this.field.displayType === 'select' && this.field.dynamicSelectConfig) {
+    if (this.field && this.field.displayType) {
+      if (this.field.displayType === 'select' && this.field.dynamicSelectConfig) {
         type = 'dataApiValue';
+      } else {
+        type = this.field.displayType;
       }
     }
 

--- a/src/app/shared/widgets/display-field/display-field.component.ts
+++ b/src/app/shared/widgets/display-field/display-field.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Field } from '../../../core/shared/model/field';
+import { Field, isFieldRightAligned } from '../../../core/shared/model/field';
 
 @Component({
   selector: 'app-display-field',
@@ -22,5 +22,9 @@ export class DisplayFieldComponent {
     }
 
     return type;
+  }
+
+  get isRightAligned(): boolean {
+    return isFieldRightAligned(this.field);
   }
 }


### PR DESCRIPTION
Fixes CAB-3902.

Summary: Row cell should always be aligned to its header cell. If it is left-aligned, left-most character of row cell should align to the left-most character of header cell. If it is right-aligned, right-most character of row cell should align to the right-most character of header cell.

Left alignment is automatically done by mat-table. Right alignment is done by matching the right-padding of the row cell and the header cell (taking into account the possibility of the up/down sorting arrow). The paddings of content inside the flex box are:

|   | Flex   | Left Padding  | Right Padding  |
|------|------|------|------|
| Header/Left/Sortable | Default | 0 | 18px (automatically mat-table up/down arrow) |
| Header/Left/Non-Sortable | Default |    0  |   inherit (automatically by mat-table)    |
| Header/Right/Sortable | Right |  0    |   18px (automatically mat-table up/down arrow)   |
| Header/Right/Non-Sortable | Right |   0   |   18px by CSS   |
| Content/Left/Sortable | Default   |  0    |  10px by CSS    |
| Content/Left/Non-Sortable | Default   |    0  |  10px by CSS    |
| Content/Right/Sortable | Right   |  0    |  18px by CSS     |
| Content/Right/Non-Sortable | Right  |  0    |   18px by CSS   |
