### PR TITLE
CAB-3985: Change "Upload Another" checkbox to "Save and Upload Another" button.

### DIFF
--- a/e2e/create/create.local-spec.ts
+++ b/e2e/create/create.local-spec.ts
@@ -9,7 +9,6 @@ import { createWriteStream, existsSync } from 'fs';
 const demoConfig = require('../mocks/profile-api/demo.json');
 const pdfFilePath = path.resolve(__dirname, '../mocks/files/sample-file.pdf');
 const docFilePath = path.resolve(__dirname, '../mocks/files/sample-file.docx');
-const textFilePath = path.resolve(__dirname, '../mocks/files/sample-file.txt');
 const invalidFilePath = path.resolve(__dirname, '../mocks/files/invalid-file.txt');
 
 const getCurrentUrl = function () {
@@ -19,7 +18,7 @@ const getCurrentUrl = function () {
 };
 
 const currentUrlMatches = (expectedUrl: string) => {
-  return () => browser.getCurrentUrl().then((currentUrl) => expectedUrl.toLowerCase() === currentUrl.toLowerCase());
+  return () => browser.getCurrentUrl().then((currentUrl) => currentUrl.toLowerCase().startsWith(expectedUrl.toLowerCase()));
 };
 
 const isEmptyFileList = (fileList: ElementArrayFinder) => {
@@ -142,17 +141,12 @@ describe('Create Page for Demo', () => {
     page.clickAcceptAlert();
   });
 
-  it("should display Upload Another checkbox that is checked by default if setting 'uploadAnother'=true", () => {
-    expect(page.uploadAnotherCheckbox.isDisplayed());
-    expect(page.uploadAnotherCheckbox.isSelected());
-  });
-
-  it('should leave form fields but clear uploaded files list after saving if upload another checkbox is checked', () => {
+  it('should leave form fields but clear uploaded files list when using Save And Upload Another buttons', () => {
     page.addFile(pdfFilePath);
     page.filerInput.sendKeys('test filer');
     expect(page.fileList.count()).toEqual(1);
 
-    page.saveButton.click();
+    page.saveAndResetButton.click();
     browser.wait(isEmptyFileList(page.fileList), 5000);
     expect(page.fileList.count()).toEqual(0);
     expect(page.filerInput.getAttribute('value')).toEqual('test filer');
@@ -167,6 +161,16 @@ describe('Create Page for Demo', () => {
     expect(page.getSnackBarText()).toContain('Failed to save 1 item');
     expect(page.fileList.count()).toEqual(1);
     expect(page.filerInput.getAttribute('value')).toEqual('test filer');
+  });
+
+  it('should redirect to search page after saving', () => {
+    page.populateRequiredFields(false);
+
+    page.addFile(pdfFilePath);
+    expect(page.fileList.count()).toEqual(1);
+
+    page.saveButton.click();
+    browser.wait(currentUrlMatches(searchPage.pageUrl), 5000);
   });
 
   it('should autocomplete Student Name when Student ID is entered in Student input field', () => {
@@ -371,20 +375,5 @@ describe('Create Page for Demo2', () => {
         'aria-required not set to true for ' + requiredField.getTagName().then((tagName) => tagName)
       );
     });
-  });
-
-  it("should display Upload Another checkbox that is un-checked by default if setting 'uploadAnother'=false", () => {
-    expect(page.uploadAnotherCheckbox.isDisplayed());
-    expect(page.uploadAnotherCheckbox.isSelected()).toBeFalsy();
-  });
-
-  it('should redirect to search page after saving if upload another checkbox is un-checked', () => {
-    page.populateRequiredFields(false);
-
-    page.addFile(pdfFilePath);
-    expect(page.fileList.count()).toEqual(1);
-
-    page.saveButton.click();
-    browser.wait(currentUrlMatches(searchPage.pageUrl), 5000);
   });
 });

--- a/e2e/create/create.po.ts
+++ b/e2e/create/create.po.ts
@@ -7,11 +7,11 @@ export class CreatePage {
   public fileList = element.all(by.tagName('mat-list-item'));
   public inputField = element(by.id('mat-input-0'));
   public errorNotification = element(by.className('error'));
-  public uploadAnotherCheckbox = element.all(by.name('uploadAnother')).get(1);
   public studentInput = element(by.css('app-student-autocomplete input'));
   public personInput = element(by.css('app-person-autocomplete input'));
   public filerInput = element(by.name('Filer'));
   public saveButton = element(by.id('saveItem'));
+  public saveAndResetButton = element(by.id('saveItemAndReset'));
   public cancelButton = element(by.id('cancel'));
   public clearButton = element(by.buttonText('clear'));
   public pdfViewer = element(by.tagName('pdf-viewer'));

--- a/e2e/mocks/profile-api/demo.json
+++ b/e2e/mocks/profile-api/demo.json
@@ -278,13 +278,16 @@
           "command": "saveItem"
         },
         {
+          "label": "Save and Upload Another",
+          "command": "saveItemAndReset"
+        },
+        {
           "label": "Cancel",
           "alwaysActive": true,
           "command": "cancel"
         }
       ],
-      "viewPanel": true,
-      "uploadAnother": true
+      "viewPanel": true
     }
   }
 }

--- a/e2e/mocks/profile-api/demo2.json
+++ b/e2e/mocks/profile-api/demo2.json
@@ -263,8 +263,7 @@
           "command": "cancel"
         }
       ],
-      "viewPanel": true,
-      "uploadAnother": false
+      "viewPanel": true
     }
   }
 }

--- a/e2e/mocks/profile-api/demo3.json
+++ b/e2e/mocks/profile-api/demo3.json
@@ -276,8 +276,7 @@
           "command": "cancel"
         }
       ],
-      "viewPanel": true,
-      "uploadAnother": false
+      "viewPanel": true
     }
   }
 }

--- a/e2e/mocks/profile-api/demo4.json
+++ b/e2e/mocks/profile-api/demo4.json
@@ -244,8 +244,7 @@
           "command": "cancel"
         }
       ],
-      "viewPanel": true,
-      "uploadAnother": false
+      "viewPanel": true
     }
   }
 }

--- a/src/app/content/content-object-list/content-object-list.component.ts
+++ b/src/app/content/content-object-list/content-object-list.component.ts
@@ -21,7 +21,6 @@ import { CustomTextUtilities } from '../../shared/directives/custom-text/custom-
 })
 export class ContentObjectListComponent implements OnInit, OnChanges, OnDestroy {
   private componentDestroyed = new Subject();
-  private uploadAnotherCtrl: AbstractControl;
 
   @Input() contentItem: ContentItem;
   @Input() formGroup: FormGroup;
@@ -52,7 +51,6 @@ export class ContentObjectListComponent implements OnInit, OnChanges, OnDestroy 
 
   ngOnInit(): void {
     this.user = this.userService.getUser();
-    this.uploadAnotherCtrl = this.formGroup && this.formGroup.controls['uploadAnother'];
 
     this.route.paramMap.pipe(takeUntil(this.componentDestroyed)).subscribe((params) => {
       this.route.data.pipe(takeUntil(this.componentDestroyed)).subscribe((data: { config: Config }) => {
@@ -294,27 +292,22 @@ export class ContentObjectListComponent implements OnInit, OnChanges, OnDestroy 
         }
 
         if (contentItem$) {
-          const contentItemSaving = contentItem$.pipe(first()).toPromise();
-          contentItemSaving
+          const contentItemSaving = contentItem$.pipe(first()).toPromise()
             .then((item) => {
               contentObject.onLoad(item);
               contentObject.failed = false;
               this.updateComponentSavedItemLists(item);
               this.saving.emit(false); // item saving completed
 
-              this.notify().then(() => {
-                if (this.uploadAnotherCtrl && this.uploadAnotherCtrl.value) {
-                  this.reset();
-                } else if (!!this.uploadAnotherCtrl) {
-                  this.router.navigate([this.config.tenant]);
-                }
-              });
+              return this.notify();
             })
             .catch((err) => {
               this.failures.push(err);
               contentObject.failed = true;
               this.saving.emit(false); // item saving failed
+
               this.notify();
+              throw err;
             });
           contentItemPromises.push(contentItemSaving);
         }

--- a/src/app/content/create-page/create-page.component.html
+++ b/src/app/content/create-page/create-page.component.html
@@ -38,14 +38,9 @@
             <div *ngIf="pageConfig?.buttons" class="button-row" style="margin: 2rem 0 1rem;text-align: right">
               <button *ngFor="let button of pageConfig?.buttons" mat-raised-button
                       (click)="buttonPress(button)" [color]="button.color"
-                      [disabled]="!button.alwaysActive &&  (form.pristine || submitPending || (button.command=='saveItem' && (form.invalid || !contentObjectListComponent.hasContentObjects())))" [id]="button.command"
+                      [disabled]="!button.alwaysActive && (form.pristine || submitPending || form.invalid || !contentObjectListComponent.hasContentObjects())" [id]="button.command"
                       [type]="button.type">{{button.label}}
               </button>
-              <span>
-                <mat-checkbox [formGroup]="form"
-                              formControlName="uploadAnother"
-                              name="uploadAnother">Upload another</mat-checkbox>
-              </span>
             </div>
           </div>
           <div fxFlex="auto" class="cs-content-view-wrapper">

--- a/src/app/content/create-page/create-page.component.ts
+++ b/src/app/content/create-page/create-page.component.ts
@@ -114,14 +114,16 @@ export class CreatePageComponent extends ComponentCanDeactivateDirective impleme
 
   private saveItemAndReset(): void {
     this.saveItemInternal().then(() => {
-      this.contentObjectListComponent && this.contentObjectListComponent.reset();
+      if (this.contentObjectListComponent) {
+        this.contentObjectListComponent.reset();
+      }
     });
   }
 
   private saveItem(): void {
     this.saveItemInternal().then(() => {
       this.router.navigate([this.config.tenant]);
-    })
+    });
   }
 
   private saveItemInternal(): Promise<any> {
@@ -148,8 +150,7 @@ export class CreatePageComponent extends ComponentCanDeactivateDirective impleme
           if (successfulSave) {
             this.form.markAsPristine(); // the entire form has saved and is no longer dirty
             return Promise.resolve();
-          }
-          else {
+          } else {
             return Promise.reject();
           }
         });

--- a/src/app/core/shared/model/content-page-config.ts
+++ b/src/app/core/shared/model/content-page-config.ts
@@ -10,10 +10,6 @@ export class ContentPageConfig implements PageConfig {
 
   viewPanel: boolean;
 
-  /**
-   * Whether the 'Upload Another' checkbox should be checked by default on the create page.
-   */
-  uploadAnother: boolean;
   allowPageByPageMode: boolean;
 
   onSave: Array<any> = [];


### PR DESCRIPTION
Features from CAB-3985 not included in PR:
- Clicking Save will bring user back to Search page -> The keyboard focus should be on the searchbox
- Clicking "Save and Upload Another" will remain on the Upload page -> The keyboard focus should be on the Browse file button.