### PR TITLE
Revert patch for Protractor 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "pretty": "prettier --parser typescript --single-quote --print-width=120 --write",
     "mock-services": "$npm_execpath start-mock-services",
     "start-mock-services": "docker container inspect content-services-api-e2e-mock || (docker build -q -t content-services-api-e2e-mock ./e2e/mocks && docker run --name content-services-api-e2e-mock --rm -d -p 12345:80 -v ${PWD}/e2e/mocks:/usr/share/nginx/html/ content-services-api-e2e-mock)",
-    "stop-mock-services": "docker stop content-services-api-e2e-mock",
-    "postinstall": "cd ./node_modules/protractor && npm i webdriver-manager@latest && webdriver-manager update"
+    "stop-mock-services": "docker stop content-services-api-e2e-mock"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
The `post-install` script was added as a patch to a bug in Protractor 5. Looks like version 7 took care of it. 