### PR TITLE
BulkEditPageComponent: Fixes the error message that is displayed in the SnackBar.

### DIFF
--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.spec.ts
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.spec.ts
@@ -308,7 +308,7 @@ describe('BulkEditPageComponent', () => {
       tick(95000);
       fixture.detectChanges();
 
-      expect(snackBarSpy.open).toHaveBeenCalledWith('Bulk update operation failed to complete, please try again. TimeoutError: Timeout has occurred', 'Dismiss');
+      expect(snackBarSpy.open).toHaveBeenCalledWith('Bulk update operation failed to complete, please try again. Error: Timeout has occurred', 'Dismiss');
     }));
   });
 });

--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.ts
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.ts
@@ -121,7 +121,7 @@ export class BulkEditPageComponent implements OnInit, OnDestroy {
         this.removeRowsById(successes.map(row => row.id));
         this.showPostUpdateMessage(successes, failures);
       },
-      err => this._snackBar.open(`Bulk update operation failed to complete, please try again. ${err}`, 'Dismiss')
+      err => this._snackBar.open(`Bulk update operation failed to complete, please try again. Error: ${err.message || err}`, 'Dismiss')
     );
   }
 


### PR DESCRIPTION
Even though the unit test looked ok, when I actually tried it live the snackbar shows [Object object] for some of the errors.