### PR TITLE
Bulk Update: Caps the maximum number of documents to select for bulk edit to 50.

### DIFF
--- a/src/app/search/search-page/search-page.component.html
+++ b/src/app/search/search-page/search-page.component.html
@@ -3,9 +3,9 @@
     <div fxFlex="20" *ngIf="!isBulkEditMode">
       <h2>{{pageConfig.pageName}}</h2>
     </div>
-    <div fxFlex="20" *ngIf="isBulkEditMode">
+    <div fxFlex="30" *ngIf="isBulkEditMode">
       <h2>Bulk Update Mode</h2>
-      <h3>Select the documents to update</h3>
+      <h3>Select a <b>maximum of {{bulkEditMaxCount}}</b> documents to update</h3>
     </div>
     <div fxFlex="70" [hidden]="!isSearchBoxVisible">
       <app-search-box
@@ -85,7 +85,9 @@
         &nbsp;
       </div>
       <div class="sticky">
-        <button class="cs-bulk-update-next-button" mat-button (click)="navigateToBulkEdit()" [disabled]="selectedRows.length === 0">
+        <button class="cs-bulk-update-next-button" mat-button
+                (click)="navigateToBulkEdit()"
+                [disabled]="selectedRows.length === 0 || selectedRows.length > bulkEditMaxCount">
           Edit {{selectedRows.length}} Documents&nbsp;
           <span class="material-icons">edit</span>
         </button>

--- a/src/app/search/search-page/search-page.component.ts
+++ b/src/app/search/search-page/search-page.component.ts
@@ -23,6 +23,7 @@ import { PersonSearchAutocomplete } from '../shared/search-autocomplete/person-s
 import { PersonService } from '../../shared/providers/person.service';
 
 const LEFT_PANEL_VISIBLE_STATE_KEY = 'isLeftPanelVisible';
+const DEFAULT_BULK_EDIT_MAX_COUNT = 50;
 
 @Component({
   selector: 'app-search-page',
@@ -47,6 +48,7 @@ export class SearchPageComponent implements OnInit, OnDestroy, AfterViewInit {
 
   initialSearchModel: SearchModel;
   isBulkEditMode = false;
+  bulkEditMaxCount = DEFAULT_BULK_EDIT_MAX_COUNT;
 
   get isLeftPanelVisible(): boolean {
     return this._isLeftPanelVisible && !this.isBulkEditMode;


### PR DESCRIPTION
Long term solution is tracked by https://jira.cac.washington.edu/browse/CAB-4078