### PR TITLE
CAB-4069: Fixes error 'ExpressionChangedAfterItHasBeenCheckedError' that is thrown when two components in the same page use the FocusDirective.

### DIFF
--- a/src/app/content/create-page/create-page.component.html
+++ b/src/app/content/create-page/create-page.component.html
@@ -51,7 +51,7 @@
                       label="Add Files"
                       (fileSelected)="addFile($event)"
                       [formGroup]="form"
-                      [autoFocus]="true"
+                      [autoFocus]="false"
                       [dropzone]="true"
                       multiple="true">
               </app-file-upload>


### PR DESCRIPTION
The focus directive is here: https://github.com/uw-it-edm/content-services-ui/blob/develop/src/app/shared/directives/focus/focus.directive.ts

When adding that directive to two elements on the page, this checked error may be thrown, the create page had two FileUploadComponents that used it to try to set auto-focus.