### PR TITLE
CAB-3812: Allow multiple Data-API backed values to be selected in UUI.

### DIFF
--- a/e2e/mocks/content-api/item.json
+++ b/e2e/mocks/content-api/item.json
@@ -24,6 +24,8 @@
     "childType": "Child2Parent2",
     "DataApiOptionLabel": "VAL_1",
     "DataApiOptionCode": "VAL_1",
+    "DataApiWithFilter": "VAL_1",
+    "DataApiOptionMultiSelect": ["VAL_1", "VAL_3"],
     "courses": "2019|autumn|PHYS|101|GROUP SCI INQUIRY I|B"
   }
 }

--- a/e2e/mocks/profile-api/demo.json
+++ b/e2e/mocks/profile-api/demo.json
@@ -67,6 +67,16 @@
       }
     },
     {
+      "key": "DataApiOptionMultiSelect",
+      "label": "DataApiOption with multi select",
+      "required": false,
+      "displayType": "multi-select",
+      "dynamicSelectConfig": {
+        "type": "test-type",
+        "labelPath": "label"
+      }
+    },
+    {
       "key": "Filer",
       "label": "Filer"
     },

--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.ts
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.ts
@@ -16,7 +16,7 @@ import { DataService } from '../../shared/providers/data.service';
 import { ContentMetadataComponent } from '../content-metadata/content-metadata.component';
 
 const ROWS_LOCAL_STORAGE_KEY = 'bulk-edit-rows';
-const UPDATE_OPERATION_TIMEOUT = (90 * 1000);
+const UPDATE_OPERATION_TIMEOUT = 90 * 1000;
 
 @Component({
   selector: 'app-bulk-edit-page',
@@ -101,23 +101,26 @@ export class BulkEditPageComponent implements OnInit, OnDestroy {
 
     this.isUpdatePending = true;
 
-    this._contentService.bulkUpdate(updatedRows).pipe(
-      timeout(UPDATE_OPERATION_TIMEOUT),
-      finalize(() => this.isUpdatePending = false),
-    ).subscribe(
-      response => {
-        const successes = (response && response.successes) || [];
-        const failures = (response && response.failures) || [];
-        this.removeRowsById(successes.map(row => row.id));
-        this.showPostUpdateMessage(successes, failures);
-      },
-      err => this._snackBar.open(`Bulk update operation failed to complete, please try again. Error: ${err.message || err}`, 'Dismiss')
-    );
+    this._contentService
+      .bulkUpdate(updatedRows)
+      .pipe(
+        timeout(UPDATE_OPERATION_TIMEOUT),
+        finalize(() => (this.isUpdatePending = false))
+      )
+      .subscribe(
+        (response) => {
+          const successes = (response && response.successes) || [];
+          const failures = (response && response.failures) || [];
+          this.removeRowsById(successes.map((row) => row.id));
+          this.showPostUpdateMessage(successes, failures);
+        },
+        (err) => this._snackBar.open(`Bulk update operation failed to complete, please try again. Error: ${err.message || err}`, 'Dismiss')
+      );
   }
 
   public removeRowsById(ids: string[]) {
     ids = ids || [];
-    this._rows = this._rows.filter(row => !ids.includes(row.id));
+    this._rows = this._rows.filter((row) => !ids.includes(row.id));
 
     const staticResults = new SearchResults();
     staticResults.results = this._rows;
@@ -129,23 +132,24 @@ export class BulkEditPageComponent implements OnInit, OnDestroy {
   private getUpdatedRows(): IContentItem[] {
     const formData = this.form.value && this.form.value.metadata;
     const updatedMetadata: { [key: string]: any } = {};
+    const isValidValue = (val) => (Array.isArray(val) ? val.length > 0 : !!val);
 
     if (!formData) {
       return [];
     }
 
     Object.keys(formData)
-          .filter(key => !!formData[key])
-          .forEach(key => updatedMetadata[key] = formData[key]);
+      .filter((key) => isValidValue(formData[key]))
+      .forEach((key) => (updatedMetadata[key] = formData[key]));
 
-    return this._rows.map(row => {
+    return this._rows.map((row) => {
       return {
         id: row.id,
         label: row.label,
         metadata: Object.assign({}, updatedMetadata, {
           ProfileId: row.metadata['ProfileId'],
-          RevisionId: row.metadata['RevisionId']
-        })
+          RevisionId: row.metadata['RevisionId'],
+        }),
       };
     });
   }
@@ -161,17 +165,17 @@ export class BulkEditPageComponent implements OnInit, OnDestroy {
   }
 
   // tslint:disable-next-line:member-ordering
-  private static extractPageConfigs(config: Config): { editConfig: BulkEditPageConfig, searchConfig: SearchPageConfig } {
+  private static extractPageConfigs(config: Config): { editConfig: BulkEditPageConfig; searchConfig: SearchPageConfig } {
     // Remove any field marked as read-only (they are not bulk-editable) and remove required validators
     const editConfig: BulkEditPageConfig = Object.assign({}, config.pages['bulk-edit']);
-    editConfig.fieldsToDisplay = editConfig.fieldsToDisplay.filter(field => !field.disabled);
-    editConfig.fieldsToDisplay = editConfig.fieldsToDisplay.map(field => Object.assign({}, field, {required: false}));
+    editConfig.fieldsToDisplay = editConfig.fieldsToDisplay.filter((field) => !field.disabled);
+    editConfig.fieldsToDisplay = editConfig.fieldsToDisplay.map((field) => Object.assign({}, field, { required: false }));
 
     const searchConfig: SearchPageConfig = Object.assign({}, config.pages['tab-search'], { defaultSort: null });
     const searchFieldKeys = editConfig.resultsTableFieldKeysToDisplay;
 
     if (searchFieldKeys && searchFieldKeys.length > 0) {
-      searchConfig.fieldsToDisplay = config.availableFields.filter(field => searchFieldKeys.includes(field.key));
+      searchConfig.fieldsToDisplay = config.availableFields.filter((field) => searchFieldKeys.includes(field.key));
     } else if (editConfig.resultsTableFieldsToDisplay) {
       searchConfig.fieldsToDisplay = editConfig.resultsTableFieldsToDisplay;
     }

--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -3,7 +3,18 @@
     <ul *ngIf="pageConfig?.fieldsToDisplay" class="fields">
       <li *ngFor="let fieldToDisplay of pageConfig.fieldsToDisplay; index as i">
         <div [ngSwitch]="fieldToDisplay.displayType">
-            <app-options-autocomplete *ngSwitchCase="'filter-select'"
+          <app-options-autocomplete *ngSwitchCase="'filter-select'"
+            [formControlName]="fieldToDisplay.key"
+            [placeholder]="fieldToDisplay.label"
+            [fieldConfig]="fieldToDisplay"
+            [parentControl]="formGroup.get('metadata').get(fieldToDisplay.dynamicSelectConfig?.parentFieldConfig?.key || '')"
+            [errorMessage]="getErrorMessage(fieldToDisplay.key)"
+            [required]="fieldHasRequiredError(fieldToDisplay)"
+            [id]="'custom-input-'+ i"
+            [attr.id]="'custom-input-'+ i">
+          </app-options-autocomplete>
+          <app-options-autocomplete *ngSwitchCase="'multi-select'"
+              [multiSelect]="true"
               [formControlName]="fieldToDisplay.key"
               [placeholder]="fieldToDisplay.label"
               [fieldConfig]="fieldToDisplay"

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -60,8 +60,8 @@ function getPageConfig({ addCascadingSelects }: { addCascadingSelects?: boolean 
       key: 'parentKey',
       label: 'Parent Label',
       displayType: 'select',
-      options: [new FieldOption('parent1'), new FieldOption('parent2')]
-    })
+      options: [new FieldOption('parent1'), new FieldOption('parent2')],
+    }),
   ];
 
   if (addCascadingSelects) {
@@ -74,9 +74,9 @@ function getPageConfig({ addCascadingSelects }: { addCascadingSelects?: boolean 
         labelPath: 'label',
         parentFieldConfig: {
           parentType: 'parent-type',
-          key: 'parentKey'
-        }
-      }
+          key: 'parentKey',
+        },
+      },
     });
 
     editPageConfig.fieldsToDisplay.push(childField);
@@ -93,7 +93,7 @@ describe('ContentMetadataComponent', () => {
   beforeEach(async(() => {
     dataApiValueServiceSpy = jasmine.createSpyObj('DataApiValueService', ['listByType', 'listByTypeAndParent']);
     const userServiceSpy: UserService = jasmine.createSpyObj('UserService', {
-      'getUser': new User('test')
+      getUser: new User('test'),
     });
 
     TestBed.configureTestingModule({
@@ -135,15 +135,23 @@ describe('ContentMetadataComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ContentMetadataComponent);
 
-    (<any>dataApiValueServiceSpy.listByTypeAndParent).withArgs('child-type', 'parent-type', 'parent1').and.returnValue(of({ content: [
-      { value: 'parent1-child1', displayValue: 'Parent 1 - Child 1' },
-      { value: 'parent1-child2', displayValue: 'Parent 1 - Child 2' },
-    ]}));
+    (<any>dataApiValueServiceSpy.listByTypeAndParent).withArgs('child-type', 'parent-type', 'parent1').and.returnValue(
+      of({
+        content: [
+          { value: 'parent1-child1', displayValue: 'Parent 1 - Child 1' },
+          { value: 'parent1-child2', displayValue: 'Parent 1 - Child 2' },
+        ],
+      })
+    );
 
-    (<any>dataApiValueServiceSpy.listByTypeAndParent).withArgs('child-type', 'parent-type', 'parent2').and.returnValue(of({ content: [
-      { value: 'parent2-child1', displayValue: 'Parent 2 - Child 1' },
-      { value: 'parent2-child2', displayValue: 'Parent 2 - Child 2' },
-    ]}));
+    (<any>dataApiValueServiceSpy.listByTypeAndParent).withArgs('child-type', 'parent-type', 'parent2').and.returnValue(
+      of({
+        content: [
+          { value: 'parent2-child1', displayValue: 'Parent 2 - Child 1' },
+          { value: 'parent2-child2', displayValue: 'Parent 2 - Child 2' },
+        ],
+      })
+    );
 
     component = fixture.componentInstance;
     component.pageConfig = getPageConfig();
@@ -220,6 +228,24 @@ describe('ContentMetadataComponent', () => {
       component.formGroup.get('metadata').get('1').reset();
       fixture.detectChanges();
       expect(component.formGroup.valid).toBeFalse();
+    });
+
+    it('should mark form as invalid when field is set to empty array if form validator is enabled', () => {
+      component.enableEmptyFormValidator = true;
+      fixture.detectChanges();
+
+      // verify form should be invalid on load
+      expect(component.formGroup.valid).toBeFalse();
+
+      // verify form is still invalid after setting a field to empty array.
+      component.formGroup.get('metadata').get('1').setValue([]);
+      fixture.detectChanges();
+      expect(component.formGroup.valid).toBeFalse();
+
+      // verify form becomes valid when setting field to array with value.
+      component.formGroup.get('metadata').get('1').setValue(['one']);
+      fixture.detectChanges();
+      expect(component.formGroup.valid).toBeTrue();
     });
 
     it('should mark form as invalid if parent select has value and child select does not when validator is enabled', fakeAsync(() => {

--- a/src/app/content/content-metadata/content-metadata.component.ts
+++ b/src/app/content/content-metadata/content-metadata.component.ts
@@ -9,11 +9,13 @@ import { isNullOrUndefined } from '../../core/util/node-utilities';
 import { PageConfig } from '../../core/shared/model/page-config';
 
 /**
- * Custom valitor that triggers if no field has values.
+ * Custom valitor that triggers if all fields have either no value set or are set 'empty' values.
  */
 const nonEmptyFormValidator: ValidatorFn = (theForm: FormGroup): ValidationErrors | null => {
   const metadata = theForm && theForm.value && theForm.value.metadata;
-  if (metadata && Object.keys(metadata).every(key => !metadata[key])) {
+  const isEmptyValue = (val) => (Array.isArray(val) ? val.length === 0 : !val);
+
+  if (metadata && Object.keys(metadata).every((key) => isEmptyValue(metadata[key]))) {
     return { incorrect: true };
   }
 
@@ -23,7 +25,7 @@ const nonEmptyFormValidator: ValidatorFn = (theForm: FormGroup): ValidationError
 @Component({
   selector: 'app-content-metadata',
   templateUrl: './content-metadata.component.html',
-  styleUrls: ['./content-metadata.component.css']
+  styleUrls: ['./content-metadata.component.css'],
 })
 export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
   private componentDestroyed = new Subject();
@@ -73,7 +75,7 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy, A
       this.formGroup.patchValue({ label: this.contentItem.label });
       const metaDataForm: FormGroup = <FormGroup>this.formGroup.controls['metadata'];
       if (!isNullOrUndefined(metaDataForm)) {
-        this.pageConfig.fieldsToDisplay.map(field => {
+        this.pageConfig.fieldsToDisplay.map((field) => {
           metaDataForm.get(field.key).patchValue(this.contentItem.metadata[field.key]);
         });
       }
@@ -113,8 +115,8 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy, A
     this.formGroup.reset();
 
     if (metadataFormGroup) {
-      Object.keys(metadataFormGroup.controls).forEach(key => {
-       metadataFormGroup.controls[key].setErrors(null);
+      Object.keys(metadataFormGroup.controls).forEach((key) => {
+        metadataFormGroup.controls[key].setErrors(null);
       });
     }
   }
@@ -135,8 +137,8 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy, A
 
   private buildCascadingFieldValidators(config: PageConfig): ValidatorFn[] {
     return (config.fieldsToDisplay || [])
-      .filter(field => field.dynamicSelectConfig && field.dynamicSelectConfig.parentFieldConfig)
-      .map(field => this.buildCascadingFieldValidator(field.dynamicSelectConfig.parentFieldConfig.key, field.key));
+      .filter((field) => field.dynamicSelectConfig && field.dynamicSelectConfig.parentFieldConfig)
+      .map((field) => this.buildCascadingFieldValidator(field.dynamicSelectConfig.parentFieldConfig.key, field.key));
   }
 
   private buildCascadingFieldValidator(parentControlKey: string, childControlKey: string): ValidatorFn {

--- a/src/app/shared/providers/fieldoption.service.ts
+++ b/src/app/shared/providers/fieldoption.service.ts
@@ -15,7 +15,6 @@ import { Field } from '../../core/shared/model/field';
  */
 @Injectable()
 export class FieldOptionService {
-
   constructor(private dataApiValueService: DataApiValueService) {}
 
   public getFieldOptions(fieldConfig: Field, parentValue?: any): Observable<FieldOption[]> {
@@ -50,18 +49,20 @@ export class FieldOptionService {
   public getOptionsFromParent(
     dynamicSelectConfig: DynamicSelectConfig,
     parentFieldConfig: ParentFieldConfig,
-    newParentValue: any
+    newParentValue: string
   ): Observable<FieldOption[]> {
-    return this.dataApiValueService
-      .listByTypeAndParent(dynamicSelectConfig.type, parentFieldConfig.parentType, newParentValue)
-      .pipe(
-        map((results: DataApiValueSearchResults) => results.content),
-        map((values: DataApiValue[]) => {
-          return values.map((value: DataApiValue) => {
-            return this.dataApiValuesToFieldOption(dynamicSelectConfig, value);
-          });
-        })
-      );
+    if (newParentValue && typeof newParentValue !== 'string') {
+      throw new Error(`Expected 'newParentValue' to be a string, actual: ${JSON.stringify(newParentValue)}`);
+    }
+
+    return this.dataApiValueService.listByTypeAndParent(dynamicSelectConfig.type, parentFieldConfig.parentType, newParentValue).pipe(
+      map((results: DataApiValueSearchResults) => results.content),
+      map((values: DataApiValue[]) => {
+        return values.map((value: DataApiValue) => {
+          return this.dataApiValuesToFieldOption(dynamicSelectConfig, value);
+        });
+      })
+    );
   }
 
   private dataApiValuesToFieldOption(dynamicSelectConfig: DynamicSelectConfig, value: DataApiValue): FieldOption {

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.html
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.html
@@ -1,13 +1,36 @@
 <mat-form-field [formGroup]="formGroup">
-  <input type="text"
+  <input type="text" *ngIf="!multiSelect"
       matInput
-      formControlName="internalAutocomplete"
+      formControlName="internalFilterControl"
       [matAutocomplete]="auto"
       [placeholder]="placeholder"
       [required]="required"
       [attr.aria-label]="placeholder"
       [attr.aria-disabled]="disabled"
       [attr.aria-required]="required" />
+
+  <mat-chip-list #chipList *ngIf="multiSelect"
+      aria-label="Options selection"
+      [required]="required"
+      [attr.aria-disabled]="disabled"
+      [attr.aria-required]="required">
+    <mat-chip
+      *ngFor="let option of selectedOptions"
+      [selectable]="!disabled"
+      [removable]="!disabled"
+      (removed)="removeOptionFromMultiSelect(option)">
+      {{option.displayValue}}
+      <mat-icon matChipRemove *ngIf="!disabled">cancel</mat-icon>
+    </mat-chip>
+    <input
+      #filterInputElement
+      formControlName="internalFilterControl"
+      [placeholder]="placeholder"
+      [attr.aria-label]="placeholder"
+      [attr.aria-disabled]="disabled"
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipList" />
+  </mat-chip-list>
 
   <mat-autocomplete #auto="matAutocomplete"
                     [displayWith]="getOptionDisplayValue"

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.html
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.html
@@ -12,22 +12,20 @@
   <mat-chip-list #chipList *ngIf="multiSelect"
       aria-label="Options selection"
       [required]="required"
+      [disabled]="disabled"
       [attr.aria-disabled]="disabled"
       [attr.aria-required]="required">
     <mat-chip
       *ngFor="let option of selectedOptions"
-      [selectable]="!disabled"
-      [removable]="!disabled"
       (removed)="removeOptionFromMultiSelect(option)">
       {{option.displayValue}}
-      <mat-icon matChipRemove *ngIf="!disabled">cancel</mat-icon>
+      <mat-icon matChipRemove>cancel</mat-icon>
     </mat-chip>
     <input
       #filterInputElement
       formControlName="internalFilterControl"
       [placeholder]="placeholder"
       [attr.aria-label]="placeholder"
-      [attr.aria-disabled]="disabled"
       [matAutocomplete]="auto"
       [matChipInputFor]="chipList" />
   </mat-chip-list>

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
@@ -220,10 +220,7 @@ describe('OptionsAutocompleteComponent', () => {
       expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy', 'polite');
     });
 
-    /**
-     * This is important for Bulk Update, where it only includes field values that have been set.
-     */
-    it('should clear the form model when the last option is removed', () => {
+    it('should set form model to empty array when the last option is removed', () => {
       component.writeValue([fieldOptions[1].value]);
       expect(component.selectedOptions[0].value).toBe(fieldOptions[1].value);
 
@@ -233,7 +230,7 @@ describe('OptionsAutocompleteComponent', () => {
       fixture.detectChanges();
 
       expect(component.selectedOptions.length).toBe(0);
-      expect(lastValue).toBeNull();
+      expect(lastValue).toEqual([]);
     });
 
     it('should filter the options list when option is selected', (done: DoneFn) => {

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { MatChipList } from '@angular/material/chips';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { of } from 'rxjs';
 import { first, skip } from 'rxjs/operators';
@@ -13,6 +14,7 @@ import { FieldOption } from '../../../core/shared/model/field/field-option';
 import { AbstractControl, FormControl } from '@angular/forms';
 import { DynamicSelectConfig } from '../../../core/shared/model/field/dynamic-select-config';
 import { ParentFieldConfig } from '../../../core/shared/model/field/parent-field-config';
+import { MaterialConfigModule } from '../../../routing/material-config.module';
 
 const fieldOptions: FieldOption[] = [
   new FieldOption('val1', 'display1 x'),
@@ -36,7 +38,7 @@ describe('OptionsAutocompleteComponent', () => {
     liveAnnouncerSpy = jasmine.createSpyObj('LiveAnnouncer', ['announce']);
 
     TestBed.configureTestingModule({
-      imports: [SharedModule, NoopAnimationsModule],
+      imports: [SharedModule, NoopAnimationsModule, MaterialConfigModule],
       declarations: [],
       providers: [
         FieldOptionService,
@@ -53,20 +55,12 @@ describe('OptionsAutocompleteComponent', () => {
     const field = new Field();
     field.options = fieldOptions;
     component.fieldConfig = field;
-    component.registerOnChange(val => {});
+    component.registerOnChange((val) => {});
 
     fixture.detectChanges();
   });
 
-  it('should populate the initial value in the formGroup control', () => {
-    component.writeValue('val1');
-
-    const option: FieldOption = component.filterInputControl.value;
-
-    expect(option.value).toBe('val1');
-  });
-
-  it('should have a correct list of options', () => {
+  it('should have a correct list of options on load', () => {
     component.filteredOptions$.subscribe((options) => {
       expect(options.length).toBe(3);
       expect(options[0].value).toBe('val1');
@@ -78,63 +72,6 @@ describe('OptionsAutocompleteComponent', () => {
     });
   });
 
-  it('should disable the formGroup control when component is disabled', () => {
-    expect(component.filterInputControl.disabled).toBeFalse();
-
-    component.setDisabledState(true);
-
-    expect(component.filterInputControl.disabled).toBeTrue();
-  });
-
-  it('should update the component value when option is selected', () => {
-    let currentValue: string;
-    component.registerOnChange(val => currentValue = val);
-    component.optionSelected(fieldOptions[1]);
-
-    expect(currentValue).toBe('val2');
-
-    expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy', 'polite');
-  });
-
-
-  // See CAB-4067. For accessibility, the list should filter down to the selected value so that it is announced on focus.
-  it('should filter the options list when option is selected', (done: DoneFn) => {
-    component.filteredOptions$.pipe(skip(1), first()).subscribe(options => {
-      // The observable chain starts with all options available, the second value will be the filtered results.
-      expect(options.length).toBe(1, 'Expect OptionsAutocompleteComponent to have 1 options.');
-      expect(options[0].displayValue).toBe('display2 xy');
-      done();
-    });
-
-    component.filterInputControl.setValue(fieldOptions[1]);
-    fixture.detectChanges();
-  });
-
-  it('should filter the options after user types in textbox', (done: DoneFn) => {
-    const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-
-    component.filteredOptions$.pipe(skip(1), first()).subscribe(options => {
-      // The observable chain starts with all options available, the second value will be the filtered results.
-      expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
-      done();
-    });
-
-    inputElement.dispatchEvent(new Event('focusin'));
-    inputElement.value = 'xy';
-    inputElement.dispatchEvent(new Event('input'));
-  });
-
-  it('should revert to the latest valid option if options list closes while invalid value is on the input', () => {
-    component.optionSelected(fieldOptions[1]);
-
-    component.filterInputControl.setValue('invalid');
-
-    component.optionListClosed();
-    fixture.detectChanges();
-
-    expect(component.filterInputControl.value).toBe(fieldOptions[1]);
-  });
-
   it('should not announce option list if input control is not typed in', fakeAsync(() => {
     component.filterInputControl.setValue(fieldOptions[1]);
     fixture.detectChanges();
@@ -143,7 +80,6 @@ describe('OptionsAutocompleteComponent', () => {
 
     expect(liveAnnouncerSpy.announce).not.toHaveBeenCalled();
   }));
-
 
   it('should announce results to screen reader after user types in textbox with more than one match', fakeAsync(() => {
     component.filterInputControl.setValue('xy');
@@ -171,6 +107,156 @@ describe('OptionsAutocompleteComponent', () => {
 
     expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Found no results.', 'polite');
   }));
+
+  describe('with single select', () => {
+    it('should populate the initial value in the formGroup control', () => {
+      component.writeValue('val1');
+
+      const option: FieldOption = component.filterInputControl.value;
+
+      expect(option.value).toBe('val1');
+    });
+
+    it('should disable the filter control when component is disabled', () => {
+      expect(component.filterInputControl.disabled).toBeFalse();
+
+      component.setDisabledState(true);
+
+      expect(component.filterInputControl.disabled).toBeTrue();
+    });
+
+    it('should filter the options after user types in textbox', (done: DoneFn) => {
+      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+
+      component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
+        // The observable chain starts with all options available, the second value will be the filtered results.
+        expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
+        done();
+      });
+
+      inputElement.dispatchEvent(new Event('focusin'));
+      inputElement.value = 'xy';
+      inputElement.dispatchEvent(new Event('input'));
+    });
+
+    it('should update the component value when option is selected', () => {
+      let currentValue: string;
+      component.registerOnChange((val) => (currentValue = val));
+      component.optionSelected(fieldOptions[1]);
+
+      expect(currentValue).toBe('val2');
+
+      expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy', 'polite');
+    });
+
+    // See CAB-4067. For accessibility, the list should filter down to the selected value so that it is announced on focus.
+    it('should filter the options list when option is selected', (done: DoneFn) => {
+      component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
+        // The observable chain starts with all options available, the second value will be the filtered results.
+        expect(options.length).toBe(1, 'Expect OptionsAutocompleteComponent to have 1 options.');
+        expect(options[0].displayValue).toBe('display2 xy');
+        done();
+      });
+
+      component.filterInputControl.setValue(fieldOptions[1]);
+      fixture.detectChanges();
+    });
+
+    it('should revert to the latest valid option if options list closes while invalid value is on the input', () => {
+      component.optionSelected(fieldOptions[1]);
+
+      component.filterInputControl.setValue('invalid');
+
+      component.optionListClosed();
+      fixture.detectChanges();
+
+      expect(component.filterInputControl.value).toBe(fieldOptions[1]);
+    });
+  });
+
+  describe('with multi select', () => {
+    beforeEach(() => {
+      component.multiSelect = true;
+      fixture.detectChanges();
+    });
+
+    it('should populate the chip list with the initial value from form model', () => {
+      component.writeValue(['val1']);
+      expect(component.selectedOptions[0].value).toBe('val1');
+    });
+
+    it('should clear the chip list when value from model is cleared', () => {
+      component.writeValue(null);
+      expect(component.selectedOptions.length).toBe(0);
+    });
+
+    it('should disable the filter control and chip list control when component is disabled', () => {
+      component.writeValue(['val1']);
+      fixture.detectChanges();
+
+      const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+      const firstChip = chipList.chips.first;
+
+      expect(component.filterInputControl.disabled).toBeFalse();
+      expect(firstChip.selectable).toBeTrue();
+      expect(firstChip.removable).toBeTrue();
+
+      component.setDisabledState(true);
+      fixture.detectChanges();
+
+      expect(component.filterInputControl.disabled).toBeTrue();
+      expect(firstChip.selectable).toBeFalse();
+      expect(firstChip.removable).toBeFalse();
+    });
+
+    it('should update the form model and add a chip when option is selected', () => {
+      let currentValues: string[];
+      component.registerOnChange((val) => (currentValues = val));
+      component.optionSelected(fieldOptions[1]);
+      fixture.detectChanges();
+
+      const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+
+      expect(component.selectedOptions[0].value).toEqual('val2');
+      expect(currentValues).toEqual(['val2']);
+      expect(chipList.chips.length).toEqual(1);
+      expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy', 'polite');
+    });
+
+    it('should filter the options list when option is selected', (done: DoneFn) => {
+      component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
+        // The observable chain starts with all options available, the second value will be the filtered results.
+        expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
+        expect(options[0].displayValue).toBe('display1 x');
+        expect(options[1].displayValue).toBe('display3 xyz');
+        done();
+      });
+
+      component.optionSelected(fieldOptions[1]);
+      fixture.detectChanges();
+    });
+
+    it('should update filter options when removing an option', () => {
+      let filteredOptions: FieldOption[] = [];
+      const subscription = component.filteredOptions$.subscribe((options) => (filteredOptions = options));
+
+      expect(filteredOptions.length).toBe(3, 'Expect to have 3 options on init.');
+
+      component.optionSelected(fieldOptions[1]);
+      fixture.detectChanges();
+
+      expect(filteredOptions.length).toBe(2, 'Expect to have 2 options after adding option.');
+      expect(component.selectedOptions.length).toEqual(1);
+
+      component.removeOptionFromMultiSelect(fieldOptions[1]);
+      fixture.detectChanges();
+
+      expect(filteredOptions.length).toBe(3, 'Expect to have 3 options after removing option.');
+      expect(component.selectedOptions.length).toEqual(0);
+
+      subscription.unsubscribe();
+    });
+  });
 });
 
 describe('OptionsAutocompleteComponent with parent control', () => {
@@ -195,9 +281,9 @@ describe('OptionsAutocompleteComponent with parent control', () => {
     component = fixture.componentInstance;
     parentControl = new FormControl('parent1');
 
-    const fieldConfig = component.fieldConfig = new Field();
-    const dynamicConfig = fieldConfig.dynamicSelectConfig = new DynamicSelectConfig();
-    const parentConfig = dynamicConfig.parentFieldConfig = new ParentFieldConfig();
+    const fieldConfig = (component.fieldConfig = new Field());
+    const dynamicConfig = (fieldConfig.dynamicSelectConfig = new DynamicSelectConfig());
+    const parentConfig = (dynamicConfig.parentFieldConfig = new ParentFieldConfig());
 
     dynamicConfig.type = 'child-type';
     dynamicConfig.labelPath = 'label';
@@ -212,7 +298,7 @@ describe('OptionsAutocompleteComponent with parent control', () => {
 
   it('should clear the filter control when the parent value changes', () => {
     let lastValue: string;
-    component.registerOnChange(val => lastValue = val);
+    component.registerOnChange((val) => (lastValue = val));
     component.filterInputControl.setValue(fieldOptions[1].value);
     fixture.detectChanges();
 

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
@@ -190,23 +190,20 @@ describe('OptionsAutocompleteComponent', () => {
       expect(component.selectedOptions.length).toBe(0);
     });
 
-    it('should disable the filter control and chip list control when component is disabled', () => {
+    it('should disable the chip list when component is disabled', () => {
       component.writeValue(['val1']);
       fixture.detectChanges();
 
       const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
-      const firstChip = chipList.chips.first;
 
       expect(component.filterInputControl.disabled).toBeFalse();
-      expect(firstChip.selectable).toBeTrue();
-      expect(firstChip.removable).toBeTrue();
+      expect(chipList.disabled).toBeFalse();
 
       component.setDisabledState(true);
       fixture.detectChanges();
 
       expect(component.filterInputControl.disabled).toBeTrue();
-      expect(firstChip.selectable).toBeFalse();
-      expect(firstChip.removable).toBeFalse();
+      expect(chipList.disabled).toBeTrue();
     });
 
     it('should update the form model and add a chip when option is selected', () => {
@@ -221,6 +218,22 @@ describe('OptionsAutocompleteComponent', () => {
       expect(currentValues).toEqual(['val2']);
       expect(chipList.chips.length).toEqual(1);
       expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy', 'polite');
+    });
+
+    /**
+     * This is important for Bulk Update, where it only includes field values that have been set.
+     */
+    it('should clear the form model when the last option is removed', () => {
+      component.writeValue([fieldOptions[1].value]);
+      expect(component.selectedOptions[0].value).toBe(fieldOptions[1].value);
+
+      let lastValue: any;
+      component.registerOnChange((val) => (lastValue = val));
+      component.removeOptionFromMultiSelect(fieldOptions[1]);
+      fixture.detectChanges();
+
+      expect(component.selectedOptions.length).toBe(0);
+      expect(lastValue).toBeNull();
     });
 
     it('should filter the options list when option is selected', (done: DoneFn) => {

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.ts
@@ -150,12 +150,7 @@ export class OptionsAutocompleteComponent implements ControlValueAccessor, OnIni
       this.liveAnnouncer.announce(`Removed ${option.displayValue}`, 'polite');
       this.selectedOptions.splice(index, 1);
       this.selectedOptionsChanged.next();
-
-      if (this.selectedOptions.length === 0) {
-        this.onChange(null);
-      } else {
-        this.onChange(this.selectedOptions.map((opt) => opt.value));
-      }
+      this.onChange(this.selectedOptions.map((opt) => opt.value));
     }
   }
 

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.ts
@@ -111,12 +111,6 @@ export class OptionsAutocompleteComponent implements ControlValueAccessor, OnIni
         takeUntil(this.componentDestroyed)
       )
       .subscribe((options) => this.announceFilteredOptions(options));
-
-    this.allOptions$.pipe(first()).subscribe(() => {
-      // For chip list with autocomplete, the disabled state of the filter control must
-      //  be set after the initial options have loaded. See: https://github.com/angular/components/issues/14036
-      this.setInnerInputDisableState();
-    });
   }
 
   ngOnDestroy(): void {
@@ -156,7 +150,12 @@ export class OptionsAutocompleteComponent implements ControlValueAccessor, OnIni
       this.liveAnnouncer.announce(`Removed ${option.displayValue}`, 'polite');
       this.selectedOptions.splice(index, 1);
       this.selectedOptionsChanged.next();
-      this.onChange(this.selectedOptions.map((opt) => opt.value));
+
+      if (this.selectedOptions.length === 0) {
+        this.onChange(null);
+      } else {
+        this.onChange(this.selectedOptions.map((opt) => opt.value));
+      }
     }
   }
 


### PR DESCRIPTION
Notes:
- Adapted from: https://material.angular.io/components/chips/examples
- There are a lot of code style changes, this is because the husky pre-commit was not running on my system before (!!). Once I fixed that, the coding style changes kicked in.
- E2E tests will be done on a separate PR.