### PR TITLE
Refactors single and multi-select into 2 components.

### DIFF
--- a/e2e/mocks/profile-api/demo.json
+++ b/e2e/mocks/profile-api/demo.json
@@ -70,10 +70,7 @@
       "key": "DataApiOptionMultiSelect",
       "label": "DataApiOption with filter multi select",
       "required": false,
-      "displayType": "filter-select",
-      "filterSelectConfig": {
-        "enableMultipleSelection": true
-      },
+      "displayType": "multi-select",
       "dynamicSelectConfig": {
         "type": "test-type",
         "labelPath": "label"

--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -4,7 +4,6 @@
       <li *ngFor="let fieldToDisplay of pageConfig.fieldsToDisplay; index as i">
         <div [ngSwitch]="fieldToDisplay.displayType">
           <app-options-autocomplete *ngSwitchCase="'filter-select'"
-            [multiSelect]="fieldToDisplay.filterSelectConfig && fieldToDisplay.filterSelectConfig.enableMultipleSelection"
             [formControlName]="fieldToDisplay.key"
             [placeholder]="fieldToDisplay.label"
             [fieldConfig]="fieldToDisplay"
@@ -14,6 +13,16 @@
             [id]="'custom-input-'+ i"
             [attr.id]="'custom-input-'+ i">
           </app-options-autocomplete>
+          <app-options-multiselect *ngSwitchCase="'multi-select'"
+            [formControlName]="fieldToDisplay.key"
+            [placeholder]="fieldToDisplay.label"
+            [fieldConfig]="fieldToDisplay"
+            [parentControl]="formGroup.get('metadata').get(fieldToDisplay.dynamicSelectConfig?.parentFieldConfig?.key || '')"
+            [errorMessage]="getErrorMessage(fieldToDisplay.key)"
+            [required]="fieldHasRequiredError(fieldToDisplay)"
+            [id]="'custom-input-'+ i"
+            [attr.id]="'custom-input-'+ i">
+          </app-options-multiselect>
           <mat-form-field *ngSwitchCase="'select'">
             <app-options-input
               [formControlName]="fieldToDisplay.key"

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -25,6 +25,7 @@ import { TimestampPickerComponent } from '../../shared/widgets/timestamp-picker/
 import { FieldOption } from '../../core/shared/model/field/field-option';
 import { OptionsInputComponent } from '../../shared/widgets/options-input/options-input.component';
 import { OptionsAutocompleteComponent } from '../../shared/widgets/options-autocomplete/options-autocomplete.component';
+import { OptionsMultiselectComponent } from '../../shared/widgets/options-multiselect/options-multiselect.component';
 import { CourseInputComponent } from '../../shared/widgets/course-input/course-input.component';
 import { Field } from '../../core/shared/model/field';
 import { DataApiValueService } from '../../shared/providers/dataapivalue.service';
@@ -117,6 +118,7 @@ describe('ContentMetadataComponent', () => {
         CheckboxInputComponent,
         OptionsInputComponent,
         OptionsAutocompleteComponent,
+        OptionsMultiselectComponent,
         CourseInputComponent,
         StudentAutocompleteComponent,
         PersonAutocompleteComponent,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -22,6 +22,7 @@ import { ProgressService } from './providers/progress.service';
 import { FocusDirective } from './directives/focus/focus.directive';
 import { OptionsInputComponent } from './widgets/options-input/options-input.component';
 import { OptionsAutocompleteComponent } from './widgets/options-autocomplete/options-autocomplete.component';
+import { OptionsMultiselectComponent } from './widgets/options-multiselect/options-multiselect.component';
 import { NotificationComponent } from './widgets/notification/notification.component';
 import { NotificationService } from './providers/notification.service';
 import { ContentViewComponent } from '../content/content-view/content-view.component';
@@ -37,15 +38,7 @@ import { CourseInputComponent } from './widgets/course-input/course-input.compon
 import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    MaterialConfigModule,
-    RouterModule,
-    ReactiveFormsModule,
-    FormsModule,
-    PdfViewerModule,
-    A11yModule,
-  ],
+  imports: [CommonModule, MaterialConfigModule, RouterModule, ReactiveFormsModule, FormsModule, PdfViewerModule, A11yModule],
   exports: [
     CommonModule,
     CustomTextDirective,
@@ -58,6 +51,7 @@ import { A11yModule } from '@angular/cdk/a11y';
     CheckboxInputComponent,
     OptionsInputComponent,
     OptionsAutocompleteComponent,
+    OptionsMultiselectComponent,
     StudentAutocompleteComponent,
     StudentDisplayComponent,
     PersonAutocompleteComponent,
@@ -81,6 +75,7 @@ import { A11yModule } from '@angular/cdk/a11y';
     CheckboxInputComponent,
     OptionsInputComponent,
     OptionsAutocompleteComponent,
+    OptionsMultiselectComponent,
     StudentAutocompleteComponent,
     StudentDisplayComponent,
     DataApiValueDisplayComponent,

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.base.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.base.ts
@@ -1,0 +1,196 @@
+import { Input, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, AbstractControl, FormControl, FormGroup, ControlValueAccessor } from '@angular/forms';
+import { Observable, Subject, concat, of, combineLatest } from 'rxjs';
+import { distinctUntilChanged, switchMap, takeUntil, startWith, map, skip, debounceTime, first } from 'rxjs/operators';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { FieldOptionService } from '../../providers/fieldoption.service';
+import { Field } from '../../../core/shared/model/field';
+import { FieldOption } from '../../../core/shared/model/field/field-option';
+
+const INTERNAL_FILTER_CONTROL_NAME = 'internalFilterControl';
+
+/**
+ * Base class for components that have an autocomplete filter.
+ */
+export class OptionsAutocompleteComponentBase implements OnInit, OnDestroy, ControlValueAccessor {
+  private _disabled = false;
+  private _filterInputControl: FormControl;
+  private allOptions$: Observable<FieldOption[]>;
+  private componentDestroyed = new Subject();
+  private _refilterOptions = new Subject();
+  private onTouch: () => void; // not used.
+  protected onChange: (value: any) => void;
+
+  formGroup: FormGroup;
+  filteredOptions$: Observable<FieldOption[]>;
+
+  @Input() placeholder: string;
+  @Input() required = false;
+  @Input() fieldConfig: Field;
+  @Input() parentControl: AbstractControl;
+  @Input() errorMessage: string;
+
+  @Input()
+  get disabled() {
+    return this._disabled;
+  }
+
+  set disabled(val: boolean) {
+    this._disabled = !!val;
+    this.setInnerInputDisableState();
+  }
+
+  get filterInputControl(): FormControl {
+    return this._filterInputControl;
+  }
+
+  constructor(private formBuilder: FormBuilder, private fieldOptionService: FieldOptionService, protected liveAnnouncer: LiveAnnouncer) {}
+
+  ngOnInit(): void {
+    this._filterInputControl = new FormControl(null);
+    this.formGroup = this.formBuilder.group({});
+    this.formGroup.controls[INTERNAL_FILTER_CONTROL_NAME] = this.filterInputControl;
+
+    this.allOptions$ = this.getAllOptions();
+    const rerunFilter$ = this._refilterOptions.asObservable().pipe(startWith(null));
+    const filter$: Observable<string | FieldOption> = this.filterInputControl.valueChanges.pipe(
+      startWith(null),
+      distinctUntilChanged(),
+      takeUntil(this.componentDestroyed)
+    );
+
+    this.filteredOptions$ = combineLatest(this.allOptions$, filter$, rerunFilter$).pipe(
+      map(([options, filter]) => options.filter((option) => this.shouldKeepOption(option, filter))),
+      takeUntil(this.componentDestroyed)
+    );
+
+    // Setup separate observable chain to update the live announcer.
+    this.filteredOptions$
+      .pipe(
+        skip(1), // Skip the initial set of options.
+        debounceTime(500),
+        takeUntil(this.componentDestroyed)
+      )
+      .subscribe((options) => this.announceFilteredOptions(options));
+  }
+
+  ngOnDestroy(): void {
+    this.componentDestroyed.next();
+    this.componentDestroyed.complete();
+  }
+
+  getOptionDisplayValue(option?: FieldOption) {
+    return option && option.displayValue;
+  }
+
+  /**
+   * This method is called by the forms API to write to the view when programmatic changes from model to view are requested.
+   */
+  writeValue(value: any): void {
+    if (value) {
+      this.allOptions$.pipe(first()).subscribe((options) => {
+        this.loadValue(value, options);
+      });
+    } else {
+      this.reset();
+    }
+  }
+
+  /**
+   * When the value changes in the UI, the registered function should be called to allow the forms API to update itself.
+   */
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouch = fn;
+  }
+
+  setDisabledState?(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  /**
+   * Resets UI to initial values.
+   */
+  protected reset(): void {
+    this.filterInputControl.reset();
+  }
+
+  /**
+   * Re-runs the refiltering logic against all available options.
+   */
+  protected refilterOptions(): void {
+    this._refilterOptions.next();
+  }
+
+  /**
+   * Runs when filtering available options, override by sub-class to return whether to keep an option in the available list.
+   */
+  protected shouldKeepOption(option: FieldOption, filter: string | FieldOption) {
+    return true;
+  }
+
+  /**
+   * Override by sub-class to write value into view when model changes programmatically.
+   */
+  protected loadValue(value: any, allOptions: FieldOption[]) {}
+
+  private setInnerInputDisableState() {
+    if (this.disabled) {
+      this.filterInputControl.disable();
+    } else {
+      this.filterInputControl.enable();
+    }
+  }
+
+  private getAllOptions(): Observable<FieldOption[]> {
+    const dynamicSelectConfig = this.fieldConfig.dynamicSelectConfig;
+    const parentFieldConfig = dynamicSelectConfig && dynamicSelectConfig.parentFieldConfig;
+    const parentControlValue = this.parentControl && this.parentControl.value;
+
+    let allOptions = this.fieldOptionService.getFieldOptions(this.fieldConfig, parentControlValue);
+
+    if (parentFieldConfig) {
+      allOptions = concat(
+        allOptions,
+        this.parentControl.valueChanges.pipe(
+          distinctUntilChanged(),
+          switchMap((newParentValue) => {
+            this.reset();
+            this.onChange(null);
+
+            if (newParentValue) {
+              return this.fieldOptionService.getOptionsFromParent(dynamicSelectConfig, parentFieldConfig, newParentValue);
+            } else {
+              return of([]);
+            }
+          }),
+          takeUntil(this.componentDestroyed)
+        )
+      );
+    }
+
+    return allOptions;
+  }
+
+  private announceFilteredOptions(options: FieldOption[]) {
+    let message: string;
+
+    if (typeof this.filterInputControl.value !== 'string') {
+      // Do not announce if input control is not being used as a filter.
+      return;
+    }
+
+    if (!options || options.length === 0) {
+      message = 'Found no results.';
+    } else if (options.length === 1) {
+      message = `Found one result: ${options[0].displayValue}.`;
+    } else {
+      message = `Found ${options.length} results.`;
+    }
+
+    this.liveAnnouncer.announce(message, 'polite');
+  }
+}

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.css
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.css
@@ -1,3 +1,0 @@
-mat-chip mat-icon.remove-option {
-  opacity: 0.7;
-}

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.html
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.html
@@ -1,5 +1,5 @@
 <mat-form-field [formGroup]="formGroup">
-  <input type="text" *ngIf="!multiSelect"
+  <input type="text"
       matInput
       formControlName="internalFilterControl"
       [matAutocomplete]="auto"
@@ -9,32 +9,11 @@
       [attr.aria-disabled]="disabled"
       [attr.aria-required]="required" />
 
-  <mat-chip-list #chipList *ngIf="multiSelect"
-      aria-label="Options selection"
-      [required]="required"
-      [disabled]="disabled"
-      [attr.aria-disabled]="disabled"
-      [attr.aria-required]="required">
-    <mat-chip *ngFor="let option of selectedOptions"
-              (removed)="removeOptionFromMultiSelect(option)">
-      {{option.displayValue}}
-      <mat-icon matChipRemove class="remove-option">cancel</mat-icon>
-    </mat-chip>
-    <input
-      #filterInputElement
-      formControlName="internalFilterControl"
-      [placeholder]="multiSelectLabelText"
-      [attr.aria-label]="placeholder"
-      [matAutocomplete]="auto"
-      [matChipInputFor]="chipList" />
-  </mat-chip-list>
-
   <mat-autocomplete #auto="matAutocomplete"
                     [displayWith]="getOptionDisplayValue"
                     (closed)="optionListClosed()"
-                    (opened)="announceWithSelectionCount()"
                     (optionSelected)="optionSelected($event.option.value)">
-    <mat-option *ngFor="let option of filteredOptions$ | async" [value]="option" [disabled]="!areMoreSelectionsAllowed">
+    <mat-option *ngFor="let option of filteredOptions$ | async" [value]="option">
       {{ option.displayValue }}
     </mat-option>
   </mat-autocomplete>

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, async, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { MatChipList } from '@angular/material/chips';
-import { MatAutocomplete } from '@angular/material/autocomplete';
+import { AbstractControl, FormControl } from '@angular/forms';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { of } from 'rxjs';
 import { first, skip } from 'rxjs/operators';
@@ -12,7 +11,6 @@ import { FieldOptionService } from '../../providers/fieldoption.service';
 import { DataApiValueService } from '../../providers/dataapivalue.service';
 import { Field } from '../../../core/shared/model/field';
 import { FieldOption } from '../../../core/shared/model/field/field-option';
-import { AbstractControl, FormControl } from '@angular/forms';
 import { DynamicSelectConfig } from '../../../core/shared/model/field/dynamic-select-config';
 import { ParentFieldConfig } from '../../../core/shared/model/field/parent-field-config';
 import { MaterialConfigModule } from '../../../routing/material-config.module';
@@ -109,222 +107,68 @@ describe('OptionsAutocompleteComponent', () => {
     expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Found no results.', 'polite');
   }));
 
-  describe('with single select', () => {
-    it('should populate the initial value in the formGroup control', () => {
-      component.writeValue('val1');
+  it('should populate the initial value in the formGroup control', () => {
+    component.writeValue('val1');
 
-      const option: FieldOption = component.filterInputControl.value;
+    const option: FieldOption = component.filterInputControl.value;
 
-      expect(option.value).toBe('val1');
-    });
-
-    it('should disable the filter control when component is disabled', () => {
-      expect(component.filterInputControl.disabled).toBeFalse();
-
-      component.setDisabledState(true);
-
-      expect(component.filterInputControl.disabled).toBeTrue();
-    });
-
-    it('should filter the options after user types in textbox', (done: DoneFn) => {
-      const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
-
-      component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
-        // The observable chain starts with all options available, the second value will be the filtered results.
-        expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
-        done();
-      });
-
-      inputElement.dispatchEvent(new Event('focusin'));
-      inputElement.value = 'xy';
-      inputElement.dispatchEvent(new Event('input'));
-    });
-
-    it('should update the component value when option is selected', () => {
-      let currentValue: string;
-      component.registerOnChange((val) => (currentValue = val));
-      component.optionSelected(fieldOptions[1]);
-
-      expect(currentValue).toBe('val2');
-
-      expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy.', 'polite');
-    });
-
-    // See CAB-4067. For accessibility, the list should filter down to the selected value so that it is announced on focus.
-    it('should filter the options list when option is selected', (done: DoneFn) => {
-      component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
-        // The observable chain starts with all options available, the second value will be the filtered results.
-        expect(options.length).toBe(1, 'Expect OptionsAutocompleteComponent to have 1 options.');
-        expect(options[0].displayValue).toBe('display2 xy');
-        done();
-      });
-
-      component.filterInputControl.setValue(fieldOptions[1]);
-      fixture.detectChanges();
-    });
-
-    it('should revert to the latest valid option if options list closes while invalid value is on the input', () => {
-      component.optionSelected(fieldOptions[1]);
-
-      component.filterInputControl.setValue('invalid');
-
-      component.optionListClosed();
-      fixture.detectChanges();
-
-      expect(component.filterInputControl.value).toBe(fieldOptions[1]);
-    });
+    expect(option.value).toBe('val1');
   });
 
-  describe('with multi select', () => {
-    beforeEach(() => {
-      component.multiSelect = true;
-      fixture.detectChanges();
+  it('should disable the filter control when component is disabled', () => {
+    expect(component.filterInputControl.disabled).toBeFalse();
+
+    component.setDisabledState(true);
+
+    expect(component.filterInputControl.disabled).toBeTrue();
+  });
+
+  it('should filter the options after user types in textbox', (done: DoneFn) => {
+    const inputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+
+    component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
+      // The observable chain starts with all options available, the second value will be the filtered results.
+      expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
+      done();
     });
 
-    it('should populate the chip list with the initial value from form model', () => {
-      component.writeValue(['val1']);
-      expect(component.selectedOptions[0].value).toBe('val1');
+    inputElement.dispatchEvent(new Event('focusin'));
+    inputElement.value = 'xy';
+    inputElement.dispatchEvent(new Event('input'));
+  });
+
+  it('should update the component value when option is selected', () => {
+    let currentValue: string;
+    component.registerOnChange((val) => (currentValue = val));
+    component.optionSelected(fieldOptions[1]);
+
+    expect(currentValue).toBe('val2');
+
+    expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy.', 'polite');
+  });
+
+  // See CAB-4067. For accessibility, the list should filter down to the selected value so that it is announced on focus.
+  it('should filter the options list when option is selected', (done: DoneFn) => {
+    component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
+      // The observable chain starts with all options available, the second value will be the filtered results.
+      expect(options.length).toBe(1, 'Expect OptionsAutocompleteComponent to have 1 options.');
+      expect(options[0].displayValue).toBe('display2 xy');
+      done();
     });
 
-    it('should clear the chip list when value from model is cleared', () => {
-      component.writeValue(null);
-      expect(component.selectedOptions.length).toBe(0);
-    });
+    component.filterInputControl.setValue(fieldOptions[1]);
+    fixture.detectChanges();
+  });
 
-    it('should disable the chip list when component is disabled', () => {
-      component.writeValue(['val1']);
-      fixture.detectChanges();
+  it('should revert to the latest valid option if options list closes while invalid value is on the input', () => {
+    component.optionSelected(fieldOptions[1]);
 
-      const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+    component.filterInputControl.setValue('invalid');
 
-      expect(component.filterInputControl.disabled).toBeFalse();
-      expect(chipList.disabled).toBeFalse();
+    component.optionListClosed();
+    fixture.detectChanges();
 
-      component.setDisabledState(true);
-      fixture.detectChanges();
-
-      expect(component.filterInputControl.disabled).toBeTrue();
-      expect(chipList.disabled).toBeTrue();
-    });
-
-    it('should update the form model and add a chip when option is selected', () => {
-      let currentValues: string[];
-      component.registerOnChange((val) => (currentValues = val));
-      component.optionSelected(fieldOptions[1]);
-      fixture.detectChanges();
-
-      const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
-
-      expect(component.selectedOptions[0].value).toEqual('val2');
-      expect(currentValues).toEqual(['val2']);
-      expect(chipList.chips.length).toEqual(1);
-      expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy.', 'polite');
-    });
-
-    it('should set form model to empty array when the last option is removed', () => {
-      component.writeValue([fieldOptions[1].value]);
-      expect(component.selectedOptions[0].value).toBe(fieldOptions[1].value);
-
-      let lastValue: any;
-      component.registerOnChange((val) => (lastValue = val));
-      component.removeOptionFromMultiSelect(fieldOptions[1]);
-      fixture.detectChanges();
-
-      expect(component.selectedOptions.length).toBe(0);
-      expect(lastValue).toEqual([]);
-    });
-
-    it('should filter the options list when option is selected', (done: DoneFn) => {
-      component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
-        // The observable chain starts with all options available, the second value will be the filtered results.
-        expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
-        expect(options[0].displayValue).toBe('display1 x');
-        expect(options[1].displayValue).toBe('display3 xyz');
-        done();
-      });
-
-      component.optionSelected(fieldOptions[1]);
-      fixture.detectChanges();
-    });
-
-    it('should update filter options when removing an option', () => {
-      let filteredOptions: FieldOption[] = [];
-      const subscription = component.filteredOptions$.subscribe((options) => (filteredOptions = options));
-
-      expect(filteredOptions.length).toBe(3, 'Expect to have 3 options on init.');
-
-      component.optionSelected(fieldOptions[1]);
-      fixture.detectChanges();
-
-      expect(filteredOptions.length).toBe(2, 'Expect to have 2 options after adding option.');
-      expect(component.selectedOptions.length).toEqual(1);
-
-      component.removeOptionFromMultiSelect(fieldOptions[1]);
-      fixture.detectChanges();
-
-      expect(filteredOptions.length).toBe(3, 'Expect to have 3 options after removing option.');
-      expect(component.selectedOptions.length).toEqual(0);
-
-      subscription.unsubscribe();
-    });
-
-    it('should default maxSelection count to max value if not specified in config', () => {
-      expect(component.maxSelectionCount).toEqual(Number.MAX_VALUE);
-    });
-
-    it('should update the placeholder of control if maxSelectionCount is set', () => {
-      component.placeholder = 'test placeholder';
-      fixture.detectChanges();
-      expect(component.multiSelectLabelText).toEqual('test placeholder');
-
-      component.maxSelectionCount = 3;
-      fixture.detectChanges();
-      expect(component.multiSelectLabelText).toEqual('test placeholder (select up to 3)');
-    });
-
-    it('should perform no operation when option selected and already at max selection count', () => {
-      let filteredOptions: FieldOption[] = [];
-      const subscription = component.filteredOptions$.subscribe((options) => (filteredOptions = options));
-
-      component.maxSelectionCount = 1;
-
-      component.optionSelected(fieldOptions[1]);
-      expect(component.selectedOptions.length).toEqual(1);
-      expect(filteredOptions.length).toEqual(2);
-
-      component.optionSelected(fieldOptions[2]);
-      expect(component.selectedOptions.length).toEqual(1);
-      expect(filteredOptions.length).toEqual(2);
-
-      subscription.unsubscribe();
-    });
-
-    it('should disable the options list when max selection count is reached', () => {
-      const autoComplete: MatAutocomplete = fixture.debugElement.query(By.directive(MatAutocomplete)).componentInstance;
-
-      component.maxSelectionCount = 1;
-      fixture.detectChanges();
-      expect(autoComplete.options.first.disabled).toBeFalsy();
-
-      component.optionSelected(fieldOptions[1]);
-      fixture.detectChanges();
-      expect(autoComplete.options.first.disabled).toBeTruthy();
-
-      component.removeOptionFromMultiSelect(fieldOptions[1]);
-      fixture.detectChanges();
-      expect(autoComplete.options.first.disabled).toBeFalsy();
-    });
-
-    it('should announce the selection counts when adding and removing options', () => {
-      component.maxSelectionCount = 1;
-      component.optionSelected(fieldOptions[1]);
-      fixture.detectChanges();
-      expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy. Selected 1 of 1 options allowed.', 'polite');
-
-      component.removeOptionFromMultiSelect(fieldOptions[1]);
-      fixture.detectChanges();
-      expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Removed display2 xy. Selected 0 of 1 options allowed.', 'polite');
-    });
+    expect(component.filterInputControl.value).toBe(fieldOptions[1]);
   });
 });
 

--- a/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.ts
+++ b/src/app/shared/widgets/options-autocomplete/options-autocomplete.component.ts
@@ -1,13 +1,9 @@
-import { Component, forwardRef, Input, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormGroup, FormBuilder, FormControl, AbstractControl } from '@angular/forms';
+import { Component, forwardRef, OnInit } from '@angular/core';
+import { NG_VALUE_ACCESSOR, FormBuilder, AbstractControl } from '@angular/forms';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
-import { Subject, Observable, of, combineLatest, concat } from 'rxjs';
-import { takeUntil, map, switchMap, startWith, first, distinctUntilChanged, debounceTime, skip } from 'rxjs/operators';
 import { FieldOption } from '../../../core/shared/model/field/field-option';
-import { Field } from '../../../core/shared/model/field';
 import { FieldOptionService } from '../../providers/fieldoption.service';
-
-const INTERNAL_FILTER_CONTROL_NAME = 'internalFilterControl';
+import { OptionsAutocompleteComponentBase } from './options-autocomplete.component.base';
 
 /**
  * Validator that checks if the selected value is an object (instead of a string which is the value used when filtering the list).
@@ -32,112 +28,18 @@ export function RequiresFieldOptionObject(control: AbstractControl) {
     },
   ],
 })
-export class OptionsAutocompleteComponent implements ControlValueAccessor, OnInit, OnDestroy {
-  private _disabled = false;
-  private _filterInputControl: FormControl;
-  private selectedOptionsChanged = new Subject();
-  private allOptions$: Observable<FieldOption[]>;
-  private componentDestroyed = new Subject();
+export class OptionsAutocompleteComponent extends OptionsAutocompleteComponentBase implements OnInit {
   private latestValidOption: FieldOption;
-  private onChange: (value: string | string[]) => void;
-  private onTouch: () => void; // not used.
 
-  @Input() multiSelect = false;
-  @Input() required = false;
-  @Input() placeholder: string;
-  @Input() fieldConfig: Field;
-  @Input() parentControl: AbstractControl;
-  @Input() errorMessage: string;
-
-  @ViewChild('filterInputElement') filterInputElement: ElementRef<HTMLInputElement>;
-
-  formGroup: FormGroup;
-  filteredOptions$: Observable<FieldOption[]>;
-  selectedOptions: FieldOption[] = [];
-  maxSelectionCount = Number.MAX_VALUE;
-
-  @Input()
-  get disabled() {
-    return this._disabled;
+  constructor(formBuilder: FormBuilder, fieldOptionService: FieldOptionService, liveAnnouncer: LiveAnnouncer) {
+    super(formBuilder, fieldOptionService, liveAnnouncer);
   }
-
-  set disabled(val: boolean) {
-    this._disabled = !!val;
-    this.setInnerInputDisableState();
-  }
-
-  get filterInputControl(): FormControl {
-    return this._filterInputControl;
-  }
-
-  get areMoreSelectionsAllowed(): boolean {
-    return this.selectedOptions.length < this.maxSelectionCount;
-  }
-
-  get multiSelectLabelText(): string {
-    if (!this.multiSelect || this.maxSelectionCount === Number.MAX_VALUE) {
-      return this.placeholder;
-    } else {
-      return `${this.placeholder} (select up to ${this.maxSelectionCount})`;
-    }
-  }
-
-  constructor(private fb: FormBuilder, private fieldOptionService: FieldOptionService, private liveAnnouncer: LiveAnnouncer) {}
 
   ngOnInit(): void {
-    const maxCountSetting = this.fieldConfig.filterSelectConfig && this.fieldConfig.filterSelectConfig.maximumSelectionCount;
-    this.maxSelectionCount = typeof maxCountSetting === 'number' ? maxCountSetting : Number.MAX_VALUE;
+    super.ngOnInit();
 
-    this._filterInputControl = new FormControl(null, this.multiSelect ? [] : [RequiresFieldOptionObject]);
-    this.formGroup = this.fb.group({});
-    this.formGroup.controls[INTERNAL_FILTER_CONTROL_NAME] = this.filterInputControl;
-
-    this.allOptions$ = this.getAllOptions();
-    const forceFilter$ = this.selectedOptionsChanged.asObservable().pipe(startWith(null));
-    const filter$: Observable<string | FieldOption> = this.filterInputControl.valueChanges.pipe(
-      startWith(null),
-      distinctUntilChanged(),
-      takeUntil(this.componentDestroyed)
-    );
-
-    this.filteredOptions$ = combineLatest(this.allOptions$, filter$, forceFilter$).pipe(
-      map(([options, filter]) =>
-        options.filter((option) => {
-          const fieldOption = filter as FieldOption;
-
-          // By default remove the options that are already in the selected options array.
-          let keepOption = this.selectedOptions.findIndex((opt) => opt.value === option.value) < 0;
-
-          if (typeof filter === 'string' && filter.length > 0) {
-            // Remove options that do not match the filter string.
-            keepOption = keepOption && option.displayValue.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
-          } else if (!this.multiSelect && fieldOption !== null && fieldOption.displayValue) {
-            keepOption = option.displayValue.toLowerCase().indexOf(fieldOption.displayValue.toLowerCase()) >= 0;
-          }
-
-          return keepOption;
-        })
-      ),
-      takeUntil(this.componentDestroyed)
-    );
-
-    // Setup separate observable chain to update the live announcer.
-    this.filteredOptions$
-      .pipe(
-        skip(1), // Skip the initial set of options.
-        debounceTime(500),
-        takeUntil(this.componentDestroyed)
-      )
-      .subscribe((options) => this.announceFilteredOptions(options));
-  }
-
-  ngOnDestroy(): void {
-    this.componentDestroyed.next();
-    this.componentDestroyed.complete();
-  }
-
-  getOptionDisplayValue(option?: FieldOption) {
-    return option && option.displayValue;
+    this.filterInputControl.setValidators([RequiresFieldOptionObject]);
+    this.filterInputControl.updateValueAndValidity();
   }
 
   optionListClosed() {
@@ -150,92 +52,34 @@ export class OptionsAutocompleteComponent implements ControlValueAccessor, OnIni
 
   optionSelected(newOption: FieldOption) {
     if (newOption) {
-      if (this.multiSelect) {
-        this.addOptionToMultiSelect(newOption);
-      } else {
-        this.latestValidOption = newOption;
-        this.onChange(newOption.value);
-      }
+      this.latestValidOption = newOption;
+      this.onChange(newOption.value);
 
-      this.announceWithSelectionCount(`Selected ${newOption.displayValue}.`);
+      this.liveAnnouncer.announce(`Selected ${newOption.displayValue}.`, 'polite');
     }
   }
 
-  removeOptionFromMultiSelect(option: FieldOption): void {
-    const index = this.selectedOptions.findIndex((opt) => opt.value === option.value);
-
-    if (index >= 0) {
-      this.selectedOptions.splice(index, 1);
-      this.selectedOptionsChanged.next();
-      this.onChange(this.selectedOptions.map((opt) => opt.value));
-      this.announceWithSelectionCount(`Removed ${option.displayValue}.`);
-    }
-  }
-
-  announceWithSelectionCount(message: string = ''): void {
-    if (this.multiSelect && this.maxSelectionCount !== Number.MAX_VALUE) {
-      message += ` Selected ${this.selectedOptions.length} of ${this.maxSelectionCount} options allowed.`;
-    }
-
-    if (message) {
-      this.liveAnnouncer.announce(message, 'polite');
-    }
-  }
-
-  /**
-   * This method is called by the forms API to write to the view when programmatic changes from model to view are requested.
-   */
-  writeValue(value: any): void {
-    if (value) {
-      this.allOptions$.pipe(first()).subscribe((options) => {
-        this.multiSelect ? this.loadMultipleValues(value, options) : this.loadSingleValue(value, options);
-      });
-    } else {
-      this.reset();
-    }
-  }
-
-  /**
-   * When the value changes in the UI, the registered function should be called to allow the forms API to update itself.
-   */
-  registerOnChange(fn: any): void {
-    this.onChange = fn;
-  }
-
-  registerOnTouched(fn: any): void {
-    this.onTouch = fn;
-  }
-
-  setDisabledState?(isDisabled: boolean): void {
-    this.disabled = isDisabled;
-  }
-
-  private reset(): void {
+  protected reset(): void {
+    super.reset();
     this.latestValidOption = null;
-    this.filterInputControl.reset();
-    this.selectedOptions = [];
-    this.selectedOptionsChanged.next();
   }
 
-  private addOptionToMultiSelect(option: FieldOption): void {
-    if (this.areMoreSelectionsAllowed) {
-      this.selectedOptions.push(option);
-      this.selectedOptionsChanged.next();
-      this.onChange(this.selectedOptions.map((opt) => opt.value));
+  protected shouldKeepOption(option: FieldOption, filter: string | FieldOption) {
+    const fieldOption = filter as FieldOption;
 
-      this.filterInputControl.reset();
-      if (this.filterInputElement) {
-        this.filterInputElement.nativeElement.value = '';
-      }
+    if (typeof filter === 'string' && filter.length > 0) {
+      return option.displayValue.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
+    } else if (fieldOption !== null && fieldOption.displayValue) {
+      return option.displayValue.toLowerCase().indexOf(fieldOption.displayValue.toLowerCase()) >= 0;
     }
+
+    return true;
   }
 
-  private loadSingleValue(selectedValue: string, allOptions: FieldOption[]): void {
+  protected loadValue(selectedValue: string, allOptions: FieldOption[]): void {
     if (typeof selectedValue !== 'string') {
       throw new Error(
-        `OptionsAutocompleteComponent with multiSelect=false expected value from model to be a string. Actual value: ${JSON.stringify(
-          selectedValue
-        )}`
+        `OptionsAutocompleteComponent expected value from model to be a string. Actual value: ${JSON.stringify(selectedValue)}`
       );
     }
 
@@ -243,76 +87,6 @@ export class OptionsAutocompleteComponent implements ControlValueAccessor, OnIni
     if (selectedOpt) {
       this.latestValidOption = selectedOpt;
       this.filterInputControl.setValue(selectedOpt);
-    }
-  }
-
-  private loadMultipleValues(selectedValues: string[], allOptions: FieldOption[]): void {
-    if (!Array.isArray(selectedValues)) {
-      throw new Error(
-        `OptionsAutocompleteComponent with multiSelect=true expected value from model to be an array. Actual value: ${JSON.stringify(
-          selectedValues
-        )}`
-      );
-    }
-
-    this.selectedOptions = allOptions.filter((opt) => selectedValues.includes(opt.value));
-    this.selectedOptionsChanged.next();
-  }
-
-  private getAllOptions(): Observable<FieldOption[]> {
-    const dynamicSelectConfig = this.fieldConfig.dynamicSelectConfig;
-    const parentFieldConfig = dynamicSelectConfig && dynamicSelectConfig.parentFieldConfig;
-    const parentControlValue = this.parentControl && this.parentControl.value;
-
-    let allOptions = this.fieldOptionService.getFieldOptions(this.fieldConfig, parentControlValue);
-
-    if (parentFieldConfig) {
-      allOptions = concat(
-        allOptions,
-        this.parentControl.valueChanges.pipe(
-          distinctUntilChanged(),
-          switchMap((newParentValue) => {
-            this.reset();
-            this.onChange(null);
-
-            if (newParentValue) {
-              return this.fieldOptionService.getOptionsFromParent(dynamicSelectConfig, parentFieldConfig, newParentValue);
-            } else {
-              return of([]);
-            }
-          }),
-          takeUntil(this.componentDestroyed)
-        )
-      );
-    }
-
-    return allOptions;
-  }
-
-  private announceFilteredOptions(options: FieldOption[]) {
-    let message: string;
-
-    if (typeof this.filterInputControl.value !== 'string') {
-      // Do not announce if input control is not being used as a filter.
-      return;
-    }
-
-    if (!options || options.length === 0) {
-      message = 'Found no results.';
-    } else if (options.length === 1) {
-      message = `Found one result: ${options[0].displayValue}.`;
-    } else {
-      message = `Found ${options.length} results.`;
-    }
-
-    this.liveAnnouncer.announce(message, 'polite');
-  }
-
-  private setInnerInputDisableState() {
-    if (this.disabled) {
-      this.filterInputControl.disable();
-    } else {
-      this.filterInputControl.enable();
     }
   }
 }

--- a/src/app/shared/widgets/options-multiselect/options-multiselect.component.css
+++ b/src/app/shared/widgets/options-multiselect/options-multiselect.component.css
@@ -1,0 +1,3 @@
+mat-chip mat-icon.remove-option {
+  opacity: 0.7;
+}

--- a/src/app/shared/widgets/options-multiselect/options-multiselect.component.html
+++ b/src/app/shared/widgets/options-multiselect/options-multiselect.component.html
@@ -1,0 +1,34 @@
+<mat-form-field [formGroup]="formGroup">
+  <mat-chip-list #chipList
+      aria-label="Options selection"
+      [required]="required"
+      [disabled]="disabled"
+      [attr.aria-disabled]="disabled"
+      [attr.aria-required]="required">
+    <mat-chip *ngFor="let option of selectedOptions"
+              (removed)="removeOptionFromMultiSelect(option)">
+      {{option.displayValue}}
+      <mat-icon matChipRemove class="remove-option">cancel</mat-icon>
+    </mat-chip>
+    <input
+      #filterInputElement
+      formControlName="internalFilterControl"
+      [placeholder]="multiSelectLabelText"
+      [attr.aria-label]="placeholder"
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipList" />
+  </mat-chip-list>
+
+  <mat-autocomplete #auto="matAutocomplete"
+                    [displayWith]="getOptionDisplayValue"
+                    (opened)="announceWithSelectionCount()"
+                    (optionSelected)="addOptionToMultiSelect($event.option.value)">
+    <mat-option *ngFor="let option of filteredOptions$ | async" [value]="option" [disabled]="!areMoreSelectionsAllowed">
+      {{ option.displayValue }}
+    </mat-option>
+  </mat-autocomplete>
+  <mat-icon *ngIf="disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
+  <mat-error>
+    {{errorMessage}}
+  </mat-error>
+</mat-form-field>

--- a/src/app/shared/widgets/options-multiselect/options-multiselect.component.spec.ts
+++ b/src/app/shared/widgets/options-multiselect/options-multiselect.component.spec.ts
@@ -1,0 +1,210 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { MatChipList } from '@angular/material/chips';
+import { MatAutocomplete } from '@angular/material/autocomplete';
+import { first, skip } from 'rxjs/operators';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { OptionsMultiselectComponent } from './options-multiselect.component';
+import { SharedModule } from '../../shared.module';
+import { FieldOptionService } from '../../providers/fieldoption.service';
+import { DataApiValueService } from '../../providers/dataapivalue.service';
+import { Field } from '../../../core/shared/model/field';
+import { FieldOption } from '../../../core/shared/model/field/field-option';
+import { MaterialConfigModule } from '../../../routing/material-config.module';
+
+const fieldOptions: FieldOption[] = [
+  new FieldOption('val1', 'display1 x'),
+  new FieldOption('val2', 'display2 xy'),
+  new FieldOption('val3', 'display3 xyz'),
+];
+
+describe('OptionsMultiselectComponent', () => {
+  let component: OptionsMultiselectComponent;
+  let fixture: ComponentFixture<OptionsMultiselectComponent>;
+  let liveAnnouncerSpy: LiveAnnouncer;
+
+  beforeEach(async(() => {
+    const dataApiValueServiceSpy = jasmine.createSpyObj('DataApiValueService', ['listByType']);
+    liveAnnouncerSpy = jasmine.createSpyObj('LiveAnnouncer', ['announce']);
+
+    TestBed.configureTestingModule({
+      imports: [SharedModule, NoopAnimationsModule, MaterialConfigModule],
+      declarations: [],
+      providers: [
+        FieldOptionService,
+        { provide: DataApiValueService, useValue: dataApiValueServiceSpy },
+        { provide: LiveAnnouncer, useValue: liveAnnouncerSpy },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OptionsMultiselectComponent);
+    component = fixture.componentInstance;
+
+    const field = new Field();
+    field.options = fieldOptions;
+    component.fieldConfig = field;
+    component.registerOnChange((val) => {});
+
+    fixture.detectChanges();
+  });
+
+  it('should have a correct list of options on load', () => {
+    component.filteredOptions$.subscribe((options) => {
+      expect(options.length).toBe(3);
+      expect(options[0].value).toBe('val1');
+      expect(options[0].displayValue).toBe('display1 x');
+      expect(options[1].value).toBe('val2');
+      expect(options[1].displayValue).toBe('display2 xy');
+      expect(options[2].value).toBe('val3');
+      expect(options[2].displayValue).toBe('display3 xyz');
+    });
+  });
+
+  it('should populate the chip list with the initial value from form model', () => {
+    component.writeValue(['val1']);
+    expect(component.selectedOptions[0].value).toBe('val1');
+  });
+
+  it('should clear the chip list when value from model is cleared', () => {
+    component.writeValue(null);
+    expect(component.selectedOptions.length).toBe(0);
+  });
+
+  it('should disable the chip list when component is disabled', () => {
+    component.writeValue(['val1']);
+    fixture.detectChanges();
+
+    const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+
+    expect(component.filterInputControl.disabled).toBeFalse();
+    expect(chipList.disabled).toBeFalse();
+
+    component.setDisabledState(true);
+    fixture.detectChanges();
+
+    expect(component.filterInputControl.disabled).toBeTrue();
+    expect(chipList.disabled).toBeTrue();
+  });
+
+  it('should update the form model and add a chip when option is selected', () => {
+    let currentValues: string[];
+    component.registerOnChange((val) => (currentValues = val));
+    component.addOptionToMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+
+    const chipList: MatChipList = fixture.debugElement.query(By.directive(MatChipList)).componentInstance;
+
+    expect(component.selectedOptions[0].value).toEqual('val2');
+    expect(currentValues).toEqual(['val2']);
+    expect(chipList.chips.length).toEqual(1);
+    expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy.', 'polite');
+  });
+
+  it('should set form model to empty array when the last option is removed', () => {
+    component.writeValue([fieldOptions[1].value]);
+    expect(component.selectedOptions[0].value).toBe(fieldOptions[1].value);
+
+    let lastValue: any;
+    component.registerOnChange((val) => (lastValue = val));
+    component.removeOptionFromMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+
+    expect(component.selectedOptions.length).toBe(0);
+    expect(lastValue).toEqual([]);
+  });
+
+  it('should filter the options list when option is selected', (done: DoneFn) => {
+    component.filteredOptions$.pipe(skip(1), first()).subscribe((options) => {
+      // The observable chain starts with all options available, the second value will be the filtered results.
+      expect(options.length).toBe(2, 'Expect OptionsAutocompleteComponent to have 2 options.');
+      expect(options[0].displayValue).toBe('display1 x');
+      expect(options[1].displayValue).toBe('display3 xyz');
+      done();
+    });
+
+    component.addOptionToMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+  });
+
+  it('should update filter options when removing an option', () => {
+    let filteredOptions: FieldOption[] = [];
+    const subscription = component.filteredOptions$.subscribe((options) => (filteredOptions = options));
+
+    expect(filteredOptions.length).toBe(3, 'Expect to have 3 options on init.');
+
+    component.addOptionToMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+
+    expect(filteredOptions.length).toBe(2, 'Expect to have 2 options after adding option.');
+    expect(component.selectedOptions.length).toEqual(1);
+
+    component.removeOptionFromMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+
+    expect(filteredOptions.length).toBe(3, 'Expect to have 3 options after removing option.');
+    expect(component.selectedOptions.length).toEqual(0);
+
+    subscription.unsubscribe();
+  });
+
+  it('should default maxSelection count to max value if not specified in config', () => {
+    expect(component.maxSelectionCount).toEqual(Number.MAX_VALUE);
+  });
+
+  it('should update the placeholder of control if maxSelectionCount is set', () => {
+    component.placeholder = 'test placeholder';
+    fixture.detectChanges();
+    expect(component.multiSelectLabelText).toEqual('test placeholder');
+
+    component.maxSelectionCount = 3;
+    fixture.detectChanges();
+    expect(component.multiSelectLabelText).toEqual('test placeholder (select up to 3)');
+  });
+
+  it('should perform no operation when option selected and already at max selection count', () => {
+    let filteredOptions: FieldOption[] = [];
+    const subscription = component.filteredOptions$.subscribe((options) => (filteredOptions = options));
+
+    component.maxSelectionCount = 1;
+
+    component.addOptionToMultiSelect(fieldOptions[1]);
+    expect(component.selectedOptions.length).toEqual(1);
+    expect(filteredOptions.length).toEqual(2);
+
+    component.addOptionToMultiSelect(fieldOptions[2]);
+    expect(component.selectedOptions.length).toEqual(1);
+    expect(filteredOptions.length).toEqual(2);
+
+    subscription.unsubscribe();
+  });
+
+  it('should disable the options list when max selection count is reached', () => {
+    const autoComplete: MatAutocomplete = fixture.debugElement.query(By.directive(MatAutocomplete)).componentInstance;
+
+    component.maxSelectionCount = 1;
+    fixture.detectChanges();
+    expect(autoComplete.options.first.disabled).toBeFalsy();
+
+    component.addOptionToMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+    expect(autoComplete.options.first.disabled).toBeTruthy();
+
+    component.removeOptionFromMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+    expect(autoComplete.options.first.disabled).toBeFalsy();
+  });
+
+  it('should announce the selection counts when adding and removing options', () => {
+    component.maxSelectionCount = 1;
+    component.addOptionToMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+    expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Selected display2 xy. Selected 1 of 1 options allowed.', 'polite');
+
+    component.removeOptionFromMultiSelect(fieldOptions[1]);
+    fixture.detectChanges();
+    expect(liveAnnouncerSpy.announce).toHaveBeenCalledWith('Removed display2 xy. Selected 0 of 1 options allowed.', 'polite');
+  });
+});

--- a/src/app/shared/widgets/options-multiselect/options-multiselect.component.ts
+++ b/src/app/shared/widgets/options-multiselect/options-multiselect.component.ts
@@ -1,0 +1,109 @@
+import { Component, forwardRef, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, FormBuilder } from '@angular/forms';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { FieldOption } from '../../../core/shared/model/field/field-option';
+import { FieldOptionService } from '../../providers/fieldoption.service';
+import { OptionsAutocompleteComponentBase } from '../options-autocomplete/options-autocomplete.component.base';
+
+@Component({
+  selector: 'app-options-multiselect',
+  templateUrl: './options-multiselect.component.html',
+  styleUrls: ['./options-multiselect.component.css'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => OptionsMultiselectComponent),
+      multi: true,
+    },
+  ],
+})
+export class OptionsMultiselectComponent extends OptionsAutocompleteComponentBase implements OnInit {
+  selectedOptions: FieldOption[] = [];
+  maxSelectionCount = Number.MAX_VALUE;
+
+  @ViewChild('filterInputElement') filterInputElement: ElementRef<HTMLInputElement>;
+
+  get areMoreSelectionsAllowed(): boolean {
+    return this.selectedOptions.length < this.maxSelectionCount;
+  }
+
+  get multiSelectLabelText(): string {
+    if (this.maxSelectionCount === Number.MAX_VALUE) {
+      return this.placeholder;
+    } else {
+      return `${this.placeholder} (select up to ${this.maxSelectionCount})`;
+    }
+  }
+
+  constructor(formBuilder: FormBuilder, fieldOptionService: FieldOptionService, liveAnnouncer: LiveAnnouncer) {
+    super(formBuilder, fieldOptionService, liveAnnouncer);
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+  }
+
+  addOptionToMultiSelect(option: FieldOption): void {
+    if (this.areMoreSelectionsAllowed) {
+      this.selectedOptions.push(option);
+      this.refilterOptions();
+      this.onChange(this.selectedOptions.map((opt) => opt.value));
+      this.announceWithSelectionCount(`Selected ${option.displayValue}.`);
+
+      this.filterInputControl.reset();
+      if (this.filterInputElement) {
+        this.filterInputElement.nativeElement.value = '';
+      }
+    }
+  }
+
+  removeOptionFromMultiSelect(option: FieldOption): void {
+    const index = this.selectedOptions.findIndex((opt) => opt.value === option.value);
+
+    if (index >= 0) {
+      this.selectedOptions.splice(index, 1);
+      this.refilterOptions();
+      this.onChange(this.selectedOptions.map((opt) => opt.value));
+      this.announceWithSelectionCount(`Removed ${option.displayValue}.`);
+    }
+  }
+
+  announceWithSelectionCount(message: string = ''): void {
+    if (this.maxSelectionCount !== Number.MAX_VALUE) {
+      message += ` Selected ${this.selectedOptions.length} of ${this.maxSelectionCount} options allowed.`;
+    }
+
+    if (message) {
+      this.liveAnnouncer.announce(message, 'polite');
+    }
+  }
+
+  protected reset(): void {
+    super.reset();
+    this.selectedOptions = [];
+    this.refilterOptions();
+  }
+
+  protected shouldKeepOption(option: FieldOption, filter: string | FieldOption) {
+    // By default remove the options that are already in the selected options array.
+    let keepOption = this.selectedOptions.findIndex((opt) => opt.value === option.value) < 0;
+
+    if (typeof filter === 'string' && filter.length > 0) {
+      // Remove options that do not match the filter string.
+      keepOption = keepOption && option.displayValue.toLowerCase().indexOf(filter.toLowerCase()) >= 0;
+    }
+
+    return keepOption;
+  }
+
+  protected loadValue(selectedValues: string[], allOptions: FieldOption[]): void {
+    if (!Array.isArray(selectedValues)) {
+      throw new Error(
+        `OptionsMultiselectComponent expected value from model to be an array. Actual value: ${JSON.stringify(selectedValues)}`
+      );
+    }
+
+    this.selectedOptions = allOptions.filter((opt) => selectedValues.includes(opt.value));
+    this.refilterOptions();
+  }
+}


### PR DESCRIPTION
The primary motivation of this PR is forward maintainability and it includes no feature work.

My initial intuition was that the single and multi select UI experience was similar enough where I would treat multiSelect as an config option. As the code base has grown, the differences between the two experiences have become greater and are primarily handled by if/else branches. I believe that keeping them separate (while still sharing common code) will make future changes easier to handle.

In broad terms, this PR:
- Moves shareable code into base class (options-autocomplete.component.base.ts).
- It's two sub-classes are options-autocomplete.component.ts and options-multiselect.component.ts, the differences between the two components are kept in their own html and ts files.

These changes can be 100% internal and don't have to change the config settings, however, I also feel that the fact that the control consumes/produces different data types depending if its single/multi select is better reflected by having a different top level control type in config ('filter-select' and 'multi-select'). I think having this split would make it clearer that these two will treat data very differently.

