### PR TITLE
CAB-4044: Allow multiple Data-API backed values to be displayed in UUI search results.

### DIFF
--- a/e2e/mocks/profile-api/demo.json
+++ b/e2e/mocks/profile-api/demo.json
@@ -193,7 +193,7 @@
         "ProfileId",
         "Filer",
         "PublishStatus",
-        "DocumentType",
+        "DataApiOptionMultiSelect",
         "LastModifiedDate",
         "childType",
         "SourceModel.childType.data.label"

--- a/e2e/mocks/search-api/search.json
+++ b/e2e/mocks/search-api/search.json
@@ -13,12 +13,17 @@
         "LastModifiedDate": 1.537446824E12,
         "InvoiceAmount": "1220.30",
         "childType": "Child2Parent2",
+        "DataApiOptionMultiSelect": ["VAL_1", "VAL_3"],
         "SourceModel": {
           "childType": {
             "data": {
               "label": "Child 2 of parent2"
             }
-          }
+          },
+          "DataApiOptionMultiSelect": [
+            { "valueId": "VAL_1", "data": { "label": "val 1 label" } },
+            { "valueId": "VAL_3", "data": { "label": "val 3 label" } }
+          ]
         }
       },
       "_score": 0.0,
@@ -37,12 +42,16 @@
         "LastModifiedDate": 1.537446824E12,
         "InvoiceAmount": "200",
         "childType": "Child2Parent1",
+        "DataApiOptionMultiSelect": ["VAL_2"],
         "SourceModel": {
           "childType": {
             "data": {
               "label": "Child 2 of parent1"
             }
-          }
+          },
+          "DataApiOptionMultiSelect": [
+            { "valueId": "VAL_2", "data": { "label": "val 2 label" } }
+          ]
         }
       },
       "_score": 0.0,
@@ -61,12 +70,24 @@
         "LastModifiedDate": 1.537246822E12,
         "InvoiceAmount": "0.15",
         "childType": "Child2Parent2",
+        "DataApiWithFilter": "VAL_1",
+        "DataApiOptionMultiSelect": ["VAL_1", "VAL_2", "VAL_3"],
         "SourceModel": {
           "childType": {
             "data": {
               "label": "Child 2 of parent2"
             }
-          }
+          },
+          "DataApiWithFilter": {
+            "data": {
+              "label": "val 1 label"
+            }
+          },
+          "DataApiOptionMultiSelect": [
+            { "valueId": "VAL_1", "data": { "label": "val 1 label" } },
+            { "valueId": "VAL_2", "data": { "label": "val 2 label" } },
+            { "valueId": "VAL_3", "data": { "label": "val 3 label" } }
+          ]
         }
       },
       "_score": 0.0,

--- a/src/app/search/search-results/search-results.component.html
+++ b/src/app/search/search-results/search-results.component.html
@@ -77,6 +77,7 @@
 
       <mat-cell *matCellDef="let element" [ngClass]="{ 'cell-align-right': isFieldRightAligned(col)}">
         <app-display-field [field]="col"
+                           [sourceModel]="getValueFromMetadata(element.metadata && element.metadata.SourceModel, col.key)"
                            [value]="getValueFromMetadata(element.metadata,col.key)"></app-display-field>
       </mat-cell>
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -33,6 +33,7 @@ import { PersonService } from './providers/person.service';
 import { PersonAutocompleteComponent } from './widgets/person-autocomplete/person-autocomplete.component';
 import { PersonDisplayComponent } from './widgets/person-display/person-display.component';
 import { DataApiValueDisplayComponent } from './widgets/data-api-display/data-api-value-display.component';
+import { ListFieldDisplayComponent } from './widgets/list-field-display/list-field-display.component';
 import { ElasticsearchDateValidatorDirective } from './directives/elasticsearch-date-validator/elasticsearch-date-validator.directive';
 import { CourseInputComponent } from './widgets/course-input/course-input.component';
 import { A11yModule } from '@angular/cdk/a11y';
@@ -57,6 +58,7 @@ import { A11yModule } from '@angular/cdk/a11y';
     PersonAutocompleteComponent,
     PersonDisplayComponent,
     DataApiValueDisplayComponent,
+    ListFieldDisplayComponent,
     TimestampPickerComponent,
     TruncatePipe,
     DisplayFieldComponent,
@@ -79,6 +81,7 @@ import { A11yModule } from '@angular/cdk/a11y';
     StudentAutocompleteComponent,
     StudentDisplayComponent,
     DataApiValueDisplayComponent,
+    ListFieldDisplayComponent,
     PersonAutocompleteComponent,
     PersonDisplayComponent,
     TimestampPickerComponent,

--- a/src/app/shared/widgets/display-field/display-field.component.html
+++ b/src/app/shared/widgets/display-field/display-field.component.html
@@ -21,6 +21,13 @@
       labelPath="{{field.dynamicSelectConfig.labelPath}}"
     ></app-data-api-display>
   </span>
+  <span *ngSwitchCase="'listValue'">
+    <app-list-field-display
+      [values]="value"
+      [selectConfig]="field.dynamicSelectConfig"
+      [sourceModel]="sourceModel">
+    </app-list-field-display>
+  </span>
   <span *ngSwitchDefault>
    {{value}}
   </span>

--- a/src/app/shared/widgets/display-field/display-field.component.ts
+++ b/src/app/shared/widgets/display-field/display-field.component.ts
@@ -4,20 +4,23 @@ import { Field, isFieldRightAligned } from '../../../core/shared/model/field';
 @Component({
   selector: 'app-display-field',
   templateUrl: './display-field.component.html',
-  styleUrls: ['./display-field.component.css']
+  styleUrls: ['./display-field.component.css'],
 })
 export class DisplayFieldComponent {
   @Input() field: Field;
   @Input() value;
+  @Input() sourceModel: { [key: string]: any };
 
   getFieldDisplayType(): string {
     let type = 'default';
 
     if (this.field && this.field.displayType) {
-      if (this.field.displayType === 'select' && this.field.dynamicSelectConfig) {
-        type = 'dataApiValue';
-      } else {
+      if (this.field.displayType === 'multi-select') {
+        type = 'listValue';
+      } else if (!this.field.dynamicSelectConfig) {
         type = this.field.displayType;
+      } else if (this.field.displayType === 'select' || this.field.displayType === 'filter-select') {
+        type = 'dataApiValue';
       }
     }
 

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.css
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.css
@@ -1,0 +1,19 @@
+.list-item {
+  white-space: nowrap;
+  margin: 10px 0;
+}
+
+.list-item .item-label {
+  padding: 3px 10px;
+  background-color: #e0e0e0;
+  border-radius: 10px;
+}
+
+.list-item .item-label.item-invalid {
+  background-color: rgba(255, 0, 0, 0.3);
+}
+
+.list-item .more-items {
+  padding: 3px 10px;
+  font-style: italic;
+}

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.html
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.html
@@ -1,0 +1,8 @@
+<div class="list-item" *ngFor="let displayValue of displayValues">
+  <span class="item-label" *ngIf="displayValue">{{displayValue}}</span>
+  <span class="item-label item-invalid" *ngIf="!displayValue">Invalid value</span>
+</div>
+
+<div class="list-item" *ngIf="values.length > 3">
+  <span class="more-items">... {{values.length - 3}} more</span>
+</div>

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.html
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.html
@@ -1,5 +1,5 @@
 <div class="list-item" *ngFor="let item of listItems">
-  <span [ngClass]="{ 'item-label': true, 'item-invalid': !item.isValid } ">{{item.displayValue}}</span>
+  <span [ngClass]="{ 'item-label': true, 'item-invalid': !item.isValid } " [matTooltip]="item.displayValue">{{item.displayValue}}</span>
 </div>
 
 <div class="list-item" *ngIf="values.length > 3">

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.html
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.html
@@ -1,6 +1,5 @@
-<div class="list-item" *ngFor="let displayValue of displayValues">
-  <span class="item-label" *ngIf="displayValue">{{displayValue}}</span>
-  <span class="item-label item-invalid" *ngIf="!displayValue">Invalid value</span>
+<div class="list-item" *ngFor="let item of listItems">
+  <span [ngClass]="{ 'item-label': true, 'item-invalid': !item.isValid } ">{{item.displayValue}}</span>
 </div>
 
 <div class="list-item" *ngIf="values.length > 3">

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.spec.ts
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.spec.ts
@@ -1,0 +1,144 @@
+import { ComponentFixture, async, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DynamicSelectConfig } from '../../../core/shared/model/field/dynamic-select-config';
+import { ListFieldDisplayComponent } from './list-field-display.component';
+
+describe('ListFieldDisplayComponent', () => {
+  let component: ListFieldDisplayComponent;
+  let fixture: ComponentFixture<ListFieldDisplayComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ListFieldDisplayComponent],
+    }).compileComponents();
+  }));
+
+  describe('with static list', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ListFieldDisplayComponent);
+      component = fixture.componentInstance;
+    });
+
+    it('should display values directly', () => {
+      component.values = ['test val 1', 'teset val 2'];
+      fixture.detectChanges();
+
+      expect(component.displayValues).toEqual(['test val 1', 'teset val 2']);
+    });
+
+    it('should remove empty values', () => {
+      component.values = [null, 'test val 1', ''];
+      fixture.detectChanges();
+
+      expect(component.displayValues).toEqual(['test val 1']);
+    });
+
+    it('should limit display values if there are more than 3 items to display', () => {
+      component.values = ['val 1', '', 'val 2', 'val 3', 'val 4'];
+      fixture.detectChanges();
+
+      expect(component.displayValues).toEqual(['val 1', 'val 2', 'val 3']);
+    });
+
+    it('should not render information text if there are 3 or less items to display', () => {
+      component.values = ['val 1', 'val 2', 'val 3'];
+      fixture.detectChanges();
+
+      const moreItemsElement = fixture.debugElement.query(By.css('.more-items'));
+      expect(moreItemsElement).toBeNull();
+    });
+
+    it('should render information text if there are more than 3 items to display', () => {
+      component.values = ['val 1', 'val 2', 'val 3', 'val 4', 'val 5'];
+      fixture.detectChanges();
+
+      const moreItemsElement = fixture.debugElement.query(By.css('.more-items'));
+      expect(moreItemsElement).not.toBeNull();
+      expect(moreItemsElement.nativeElement.textContent).toEqual('... 2 more');
+    });
+  });
+
+  describe('with data-api backed list', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ListFieldDisplayComponent);
+      component = fixture.componentInstance;
+      component.selectConfig = new DynamicSelectConfig();
+    });
+
+    it('should display items from source model', () => {
+      component.values = ['val1', 'val2'];
+      component.sourceModel = [
+        { valueId: 'val1', data: { label: 'value 1' } },
+        { valueId: 'val2', data: { label: 'value 2' } },
+      ];
+      fixture.detectChanges();
+
+      expect(component.displayValues).toEqual(['value 1', 'value 2']);
+    });
+
+    it('should use the label path to get item text', () => {
+      component.selectConfig.labelPath = 'key.path';
+      component.values = ['val1'];
+      component.sourceModel = [
+        {
+          valueId: 'val1',
+          data: {
+            key: {
+              path: 'value 1',
+            },
+          },
+        },
+      ];
+      fixture.detectChanges();
+
+      expect(component.displayValues).toEqual(['value 1']);
+    });
+
+    it('should limit display values and show information text if there are more than 3 items to display', () => {
+      component.values = ['val1', 'val2', 'val3', 'val4'];
+      component.sourceModel = [
+        { valueId: 'val1', data: { label: 'value 1' } },
+        { valueId: 'val2', data: { label: 'value 2' } },
+        { valueId: 'val3', data: { label: 'value 3' } },
+      ];
+      fixture.detectChanges();
+
+      const moreItemsElement = fixture.debugElement.query(By.css('.more-items'));
+
+      expect(component.displayValues).toEqual(['value 1', 'value 2', 'value 3']);
+      expect(moreItemsElement).not.toBeNull();
+      expect(moreItemsElement.nativeElement.textContent).toEqual('... 1 more');
+    });
+
+    it('should add invalid item if source model is missing', () => {
+      component.values = ['val1', 'val2'];
+      component.sourceModel = null;
+      fixture.detectChanges();
+
+      const invalidItems = fixture.debugElement.queryAll(By.css('.item-invalid'));
+
+      expect(component.displayValues).toEqual([null, null]);
+      expect(invalidItems.length).toEqual(2);
+      expect(invalidItems[0].nativeElement.textContent).toEqual('Invalid value');
+    });
+
+    it('should add invalid item if source model is missing properties', () => {
+      component.values = ['val1', 'val2'];
+      component.sourceModel = [{ valueId: 'val1', data: { otherLabel: 'value 1' } }];
+      fixture.detectChanges();
+
+      const invalidItems = fixture.debugElement.queryAll(By.css('.item-invalid'));
+
+      // One of the values is missing from the source model, the other is there but the label path is wrong.
+      expect(invalidItems.length).toEqual(2);
+      expect(invalidItems[0].nativeElement.textContent).toEqual('Invalid value');
+    });
+
+    it('should throw error if source model is not an array', () => {
+      component.values = ['val1'];
+      component.sourceModel = <any>{ valueId: 'val1', data: { label: 'value 1' } };
+
+      expect(() => fixture.detectChanges()).toThrowError('Input sourceModel should be an array. Current type: object');
+    });
+  });
+});

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.spec.ts
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.spec.ts
@@ -7,6 +7,10 @@ describe('ListFieldDisplayComponent', () => {
   let component: ListFieldDisplayComponent;
   let fixture: ComponentFixture<ListFieldDisplayComponent>;
 
+  const getDisplayValues = (): string[] => {
+    return component.listItems.map((item) => item.displayValue);
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ListFieldDisplayComponent],
@@ -20,24 +24,24 @@ describe('ListFieldDisplayComponent', () => {
     });
 
     it('should display values directly', () => {
-      component.values = ['test val 1', 'teset val 2'];
+      component.values = ['test val 1', 'test val 2'];
       fixture.detectChanges();
 
-      expect(component.displayValues).toEqual(['test val 1', 'teset val 2']);
+      expect(getDisplayValues()).toEqual(['test val 1', 'test val 2']);
     });
 
     it('should remove empty values', () => {
       component.values = [null, 'test val 1', ''];
       fixture.detectChanges();
 
-      expect(component.displayValues).toEqual(['test val 1']);
+      expect(getDisplayValues()).toEqual(['test val 1']);
     });
 
     it('should limit display values if there are more than 3 items to display', () => {
       component.values = ['val 1', '', 'val 2', 'val 3', 'val 4'];
       fixture.detectChanges();
 
-      expect(component.displayValues).toEqual(['val 1', 'val 2', 'val 3']);
+      expect(getDisplayValues()).toEqual(['val 1', 'val 2', 'val 3']);
     });
 
     it('should not render information text if there are 3 or less items to display', () => {
@@ -68,12 +72,12 @@ describe('ListFieldDisplayComponent', () => {
     it('should display items from source model', () => {
       component.values = ['val1', 'val2'];
       component.sourceModel = [
-        { valueId: 'val1', data: { label: 'value 1' } },
-        { valueId: 'val2', data: { label: 'value 2' } },
+        { valueId: 'val1', type: null, data: { label: 'value 1' } },
+        { valueId: 'val2', type: null, data: { label: 'value 2' } },
       ];
       fixture.detectChanges();
 
-      expect(component.displayValues).toEqual(['value 1', 'value 2']);
+      expect(getDisplayValues()).toEqual(['value 1', 'value 2']);
     });
 
     it('should use the label path to get item text', () => {
@@ -82,6 +86,7 @@ describe('ListFieldDisplayComponent', () => {
       component.sourceModel = [
         {
           valueId: 'val1',
+          type: null,
           data: {
             key: {
               path: 'value 1',
@@ -91,47 +96,47 @@ describe('ListFieldDisplayComponent', () => {
       ];
       fixture.detectChanges();
 
-      expect(component.displayValues).toEqual(['value 1']);
+      expect(getDisplayValues()).toEqual(['value 1']);
     });
 
     it('should limit display values and show information text if there are more than 3 items to display', () => {
       component.values = ['val1', 'val2', 'val3', 'val4'];
       component.sourceModel = [
-        { valueId: 'val1', data: { label: 'value 1' } },
-        { valueId: 'val2', data: { label: 'value 2' } },
-        { valueId: 'val3', data: { label: 'value 3' } },
+        { valueId: 'val1', type: null, data: { label: 'value 1' } },
+        { valueId: 'val2', type: null, data: { label: 'value 2' } },
+        { valueId: 'val3', type: null, data: { label: 'value 3' } },
       ];
       fixture.detectChanges();
 
-      const moreItemsElement = fixture.debugElement.query(By.css('.more-items'));
+      expect(getDisplayValues()).toEqual(['value 1', 'value 2', 'value 3']);
 
-      expect(component.displayValues).toEqual(['value 1', 'value 2', 'value 3']);
+      const moreItemsElement = fixture.debugElement.query(By.css('.more-items'));
       expect(moreItemsElement).not.toBeNull();
       expect(moreItemsElement.nativeElement.textContent).toEqual('... 1 more');
     });
 
-    it('should add invalid item if source model is missing', () => {
+    it('should use raw value and add error class if source model is missing', () => {
       component.values = ['val1', 'val2'];
       component.sourceModel = null;
       fixture.detectChanges();
 
-      const invalidItems = fixture.debugElement.queryAll(By.css('.item-invalid'));
+      expect(getDisplayValues()).toEqual(['val1', 'val2']);
 
-      expect(component.displayValues).toEqual([null, null]);
+      const invalidItems = fixture.debugElement.queryAll(By.css('.item-invalid'));
       expect(invalidItems.length).toEqual(2);
-      expect(invalidItems[0].nativeElement.textContent).toEqual('Invalid value');
+      expect(invalidItems[0].nativeElement.textContent).toEqual('val1');
     });
 
-    it('should add invalid item if source model is missing properties', () => {
+    it('should use raw value if source model is missing properties', () => {
       component.values = ['val1', 'val2'];
-      component.sourceModel = [{ valueId: 'val1', data: { otherLabel: 'value 1' } }];
+      component.sourceModel = [{ valueId: 'val1', type: null, data: { otherLabel: 'value 1' } }];
       fixture.detectChanges();
 
-      const invalidItems = fixture.debugElement.queryAll(By.css('.item-invalid'));
-
       // One of the values is missing from the source model, the other is there but the label path is wrong.
+      expect(getDisplayValues()).toEqual(['val1', 'val2']);
+
+      const invalidItems = fixture.debugElement.queryAll(By.css('.item-invalid'));
       expect(invalidItems.length).toEqual(2);
-      expect(invalidItems[0].nativeElement.textContent).toEqual('Invalid value');
     });
 
     it('should throw error if source model is not an array', () => {

--- a/src/app/shared/widgets/list-field-display/list-field-display.component.ts
+++ b/src/app/shared/widgets/list-field-display/list-field-display.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { DynamicSelectConfig } from '../../../core/shared/model/field/dynamic-select-config';
+import { ObjectUtilities } from '../../../core/util/object-utilities';
+
+const DEFAULT_LABEL_PATH = 'label';
+
+@Component({
+  selector: 'app-list-field-display',
+  templateUrl: './list-field-display.component.html',
+  styleUrls: ['./list-field-display.component.css'],
+})
+export class ListFieldDisplayComponent implements OnInit {
+  displayValues: string[] = [];
+
+  @Input() selectConfig: DynamicSelectConfig;
+  @Input() values: string[] = [];
+  @Input() sourceModel: { valueId: string; data: { [key: string]: any } }[] = [];
+
+  constructor() {}
+
+  ngOnInit(): void {
+    if (this.sourceModel && !Array.isArray(this.sourceModel)) {
+      throw new Error(`Input sourceModel should be an array. Current type: ${typeof this.sourceModel}`);
+    }
+
+    this.sourceModel = this.sourceModel || [];
+    this.values = this.values || [];
+
+    if (this.selectConfig) {
+      this.displayValues = this.getDisplayValues(this.values.slice(0, 3));
+    } else {
+      this.displayValues = this.values.filter((val) => !!val).slice(0, 3);
+    }
+  }
+
+  private getDisplayValues(values: string[]): string[] {
+    const displayPath = (this.selectConfig && this.selectConfig.labelPath) || DEFAULT_LABEL_PATH;
+
+    return values.map((value) => {
+      const valueSourceModel = this.sourceModel.find((sourceModel) => sourceModel.valueId === value);
+
+      if (valueSourceModel) {
+        return ObjectUtilities.getNestedObjectFromStringPath(valueSourceModel.data, displayPath);
+      }
+
+      return null;
+    });
+  }
+}


### PR DESCRIPTION
Notes:
- Same component can be used for data-api backed list as well as static lists.
- We can definitely change the UI going forward, but I feel this is decent enough for the first iteration.
- Only uses information from 'SourceModel', a subsequent PR will make a similar change for the 'DataApiValueDisplayComponent'.