### PR TITLE
Adds ability to override properties when using field references.

### DIFF
--- a/src/app/core/shared/config.service.spec.ts
+++ b/src/app/core/shared/config.service.spec.ts
@@ -5,8 +5,10 @@ import { User } from '../../user/shared/user';
 import { ProgressService } from '../../shared/providers/progress.service';
 import { Config } from './model/config';
 import { environment } from '../../../environments/environment';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { TenantConfigInfo } from './model/tenant-config-info';
+import { Field } from './model/field';
+import { PageConfig } from './model/page-config';
 
 let httpSpy;
 let http: HttpClient;
@@ -15,12 +17,12 @@ let service: ConfigService;
 const profileLinks = {
   _links: {
     demo: {
-      href: 'http://profile-api-mock.edm/profile/v1/app/my-app/demo'
+      href: 'http://profile-api-mock.edm/profile/v1/app/my-app/demo',
     },
     'mech-eng-procard': {
-      href: 'http://profile-api-mock.edm/profile/v1/app/my-app/mech-eng-procard'
-    }
-  }
+      href: 'http://profile-api-mock.edm/profile/v1/app/my-app/mech-eng-procard',
+    },
+  },
 };
 
 describe('ConfigService', () => {
@@ -47,7 +49,7 @@ describe('ConfigService', () => {
     expect(service.getConfigForTenant('test')).toBeTruthy();
   });
 
-  it('should getTenantList', () => {
+  it('should getTenantList', (done: DoneFn) => {
     const response$ = of(profileLinks);
     httpSpy = spyOn(http, 'get').and.returnValue(response$);
 
@@ -58,10 +60,12 @@ describe('ConfigService', () => {
       expect(tenants.length).toEqual(2);
       expect(tenants[0].tenantName).toBe('demo');
       expect(tenants[1].tenantName).toBe('mech-eng-procard');
+
+      done();
     });
   });
 
-  it('should have a Demo profile', () => {
+  it('should have a Demo profile', (done: DoneFn) => {
     const demo = new Config();
     demo.tenant = 'demo';
 
@@ -70,10 +74,56 @@ describe('ConfigService', () => {
     httpSpy = spyOn(http, 'get').and.returnValues(profileLinksResponse$, tenantResponse$);
 
     const expectedUrl = profileLinks._links['demo'].href;
-    service.getConfigForTenant('demo').then(demoConfig => {
+    service.getConfigForTenant('demo').then((demoConfig) => {
       expect(httpSpy).toHaveBeenCalledTimes(2);
       expect(httpSpy.calls.mostRecent().args[0]).toBe(expectedUrl);
       expect(demoConfig.tenant).toBe('demo');
+
+      done();
+    });
+  });
+
+  it('should override field properties specified on the fieldOverrides array', (done: DoneFn) => {
+    const field = new Field();
+    field.key = 'field1';
+    field.displayType = 'select';
+
+    const page: PageConfig = {
+      pageName: 'page1',
+      theme: 'theme1',
+      fieldsToDisplay: [],
+      fieldKeysToDisplay: ['field1'],
+      fieldOverrides: [
+        {
+          key: 'field1',
+          overrides: {
+            disabled: true,
+          },
+        },
+      ],
+    };
+
+    const demo = new Config();
+    demo.tenant = 'demo';
+    demo.availableFields = [field];
+    demo.pages['page1'] = page;
+
+    const profileLinksResponse$ = of(profileLinks);
+    const tenantResponse$ = of(demo);
+    httpSpy = spyOn(http, 'get').and.returnValues(profileLinksResponse$, tenantResponse$);
+
+    service.getConfigForTenant('demo').then((demoConfig) => {
+      const demoPage: PageConfig = demoConfig.pages['page1'];
+      expect(demoPage.fieldsToDisplay.length).toEqual(1);
+
+      // verify 'disabled' property was overriden and 'displayType' was kept
+      expect(demoPage.fieldsToDisplay[0].disabled).toBeTrue();
+      expect(demoPage.fieldsToDisplay[0].displayType).toEqual('select');
+
+      // verify 'disabled' property was not modified on the reference field
+      expect(demoConfig.availableFields[0].disabled).toBeFalse();
+
+      done();
     });
   });
 });

--- a/src/app/core/shared/config.service.spec.ts
+++ b/src/app/core/shared/config.service.spec.ts
@@ -96,7 +96,7 @@ describe('ConfigService', () => {
       fieldOverrides: [
         {
           key: 'field1',
-          overrides: {
+          override: {
             disabled: true,
           },
         },

--- a/src/app/core/shared/config.service.ts
+++ b/src/app/core/shared/config.service.ts
@@ -9,14 +9,14 @@ import { ProgressService } from '../../shared/providers/progress.service';
 import { UserService } from '../../user/shared/user.service';
 import { TenantConfigInfo } from './model/tenant-config-info';
 import { Field } from './model/field';
+import { PageConfig } from './model/page-config';
 
 @Injectable()
 export class ConfigService {
   private configs: Map<string, Config> = new Map();
   private tenantsConfig = null;
 
-  private appConfigUrl =
-    environment.profile_api.url + environment.profile_api.context + '/app/' + environment.profile_api.app_name;
+  private appConfigUrl = environment.profile_api.url + environment.profile_api.context + '/app/' + environment.profile_api.app_name;
 
   constructor(private http: HttpClient, private progressService: ProgressService, private userService: UserService) {}
 
@@ -25,9 +25,9 @@ export class ConfigService {
     return this.getTenantList()
       .toPromise()
       .then(
-        tenants => {
+        (tenants) => {
           this.progressService.end();
-          const tenantInfo = tenants.find(tenantInList => {
+          const tenantInfo = tenants.find((tenantInList) => {
             return tenantInList.tenantName === requestedTenant;
           });
           if (tenantInfo) {
@@ -36,7 +36,7 @@ export class ConfigService {
             return Promise.reject('No such tenant : ' + requestedTenant);
           }
         },
-        err => {
+        (err) => {
           this.progressService.end();
           return Promise.reject(err);
         }
@@ -57,7 +57,7 @@ export class ConfigService {
       return this.http
         .get<Config>(tenantInfo.downloadUrl, requestOptions)
         .pipe(
-          tap(config => this.configs.set(tenantInfo.tenantName, this.buildConfig(config))),
+          tap((config) => this.configs.set(tenantInfo.tenantName, this.buildConfig(config))),
           publishReplay(1),
           refCount()
         )
@@ -68,20 +68,32 @@ export class ConfigService {
   private buildConfig(config: Config) {
     const availableFieldsMap = new Map<string, Field>();
     if (config.availableFields) {
-      config.availableFields.map(value => availableFieldsMap.set(value.key, value));
+      config.availableFields.map((value) => availableFieldsMap.set(value.key, value));
 
-      Object.keys(config.pages).forEach(pageKey => {
-        const pageConfig = config.pages[pageKey];
+      Object.keys(config.pages).forEach((pageKey) => {
+        const pageConfig: PageConfig = config.pages[pageKey];
 
         if (!pageConfig.fieldsToDisplay) {
           pageConfig.fieldsToDisplay = [];
         }
+
         if (pageConfig.fieldKeysToDisplay) {
-          pageConfig.fieldKeysToDisplay.forEach(field => {
+          pageConfig.fieldKeysToDisplay.forEach((field) => {
             if (!availableFieldsMap.has(field)) {
               throw new Error('No Such field : ' + field);
             }
             pageConfig.fieldsToDisplay.push(availableFieldsMap.get(field));
+          });
+        }
+
+        if (pageConfig.fieldOverrides) {
+          pageConfig.fieldOverrides.forEach((fieldOverride) => {
+            const fieldIndex = pageConfig.fieldsToDisplay.findIndex((field) => field.key === fieldOverride.key);
+
+            if (fieldIndex >= 0) {
+              const fieldConfig = pageConfig.fieldsToDisplay[fieldIndex];
+              pageConfig.fieldsToDisplay[fieldIndex] = Object.assign({}, fieldConfig, fieldOverride.overrides);
+            }
           });
         }
       });
@@ -99,7 +111,7 @@ export class ConfigService {
       console.log('getTenantList');
       const requestOptions = this.buildRequestOptions();
       return this.http.get(this.appConfigUrl, requestOptions).pipe(
-        map(result => {
+        map((result) => {
           const tenants: TenantConfigInfo[] = [];
 
           const tenantsFromAPI = result['_links'];
@@ -117,7 +129,7 @@ export class ConfigService {
             return a.tenantName.localeCompare(b.tenantName);
           });
         }),
-        tap(tenantsConfig => {
+        tap((tenantsConfig) => {
           this.tenantsConfig = tenantsConfig;
         }),
         publishReplay(1),
@@ -130,10 +142,7 @@ export class ConfigService {
     const requestOptionsArgs = {};
     if (environment.profile_api.authenticationHeader) {
       const user = this.userService.getUser();
-      requestOptionsArgs['headers'] = new HttpHeaders().append(
-        environment.profile_api.authenticationHeader,
-        user.actAs
-      );
+      requestOptionsArgs['headers'] = new HttpHeaders().append(environment.profile_api.authenticationHeader, user.actAs);
     }
 
     return requestOptionsArgs;

--- a/src/app/core/shared/config.service.ts
+++ b/src/app/core/shared/config.service.ts
@@ -92,7 +92,7 @@ export class ConfigService {
 
             if (fieldIndex >= 0) {
               const fieldConfig = pageConfig.fieldsToDisplay[fieldIndex];
-              pageConfig.fieldsToDisplay[fieldIndex] = Object.assign({}, fieldConfig, fieldOverride.overrides);
+              pageConfig.fieldsToDisplay[fieldIndex] = Object.assign({}, fieldConfig, fieldOverride.override);
             }
           });
         }

--- a/src/app/core/shared/config.service.ts
+++ b/src/app/core/shared/config.service.ts
@@ -86,14 +86,17 @@ export class ConfigService {
           });
         }
 
-        if (pageConfig.fieldOverrides) {
-          pageConfig.fieldOverrides.forEach((fieldOverride) => {
-            const fieldIndex = pageConfig.fieldsToDisplay.findIndex((field) => field.key === fieldOverride.key);
+        if (pageConfig.fieldReferencesToDisplay) {
+          const fieldRefs = pageConfig.fieldReferencesToDisplay.map((ref) => (typeof ref === 'string' ? { key: ref } : ref));
 
-            if (fieldIndex >= 0) {
-              const fieldConfig = pageConfig.fieldsToDisplay[fieldIndex];
-              pageConfig.fieldsToDisplay[fieldIndex] = Object.assign({}, fieldConfig, fieldOverride.override);
+          fieldRefs.forEach((fieldRef) => {
+            const fieldConfig = availableFieldsMap.get(fieldRef.key);
+
+            if (!fieldConfig) {
+              throw new Error(`Field in page '${pageConfig.pageName}' referenced by key '${fieldRef.key}' was not found.`);
             }
+
+            pageConfig.fieldsToDisplay.push(Object.assign({}, fieldConfig, fieldRef.override));
           });
         }
       });

--- a/src/app/core/shared/model/field.ts
+++ b/src/app/core/shared/model/field.ts
@@ -4,6 +4,11 @@ import { DynamicSelectConfig } from './field/dynamic-select-config';
 import { CourseConfig } from './field/course-config';
 import { MultiSelectConfig } from './multi-select-config';
 
+/**
+ * Used to refer to a field by 'key'.
+ */
+export type FieldReference = string | { key: string; override?: Object };
+
 export type FieldDataType = 'string' | 'number' | 'date';
 export type FieldDisplayType =
   | 'date'

--- a/src/app/core/shared/model/page-config.ts
+++ b/src/app/core/shared/model/page-config.ts
@@ -1,4 +1,4 @@
-import { Field } from './field';
+import { Field, FieldReference } from './field';
 
 export interface PageConfig {
   pageName: string;
@@ -7,7 +7,7 @@ export interface PageConfig {
   fieldKeysToDisplay: Array<string>;
 
   /**
-   * Specifies values to override when using field references.
+   * A list of field references to display (identified by the 'key' in the availableFields list).
    */
-  fieldOverrides?: { key: string; override: Object }[];
+  fieldReferencesToDisplay?: FieldReference[];
 }

--- a/src/app/core/shared/model/page-config.ts
+++ b/src/app/core/shared/model/page-config.ts
@@ -5,4 +5,9 @@ export interface PageConfig {
   theme: string;
   fieldsToDisplay: Array<Field>;
   fieldKeysToDisplay: Array<string>;
+
+  /**
+   * Specifies values to override when using field references.
+   */
+  fieldOverrides?: { key: string; overrides: Object }[];
 }

--- a/src/app/core/shared/model/page-config.ts
+++ b/src/app/core/shared/model/page-config.ts
@@ -9,5 +9,5 @@ export interface PageConfig {
   /**
    * Specifies values to override when using field references.
    */
-  fieldOverrides?: { key: string; overrides: Object }[];
+  fieldOverrides?: { key: string; override: Object }[];
 }


### PR DESCRIPTION
The idea behind this feature is to be able to define the fields used for a profile once and re-use them for all pages. For EHS Radiation profile it will allow config to override just the one property that is different for the edit page:
```
fieldReferencesToDisplay: [
  { key: 'ReleaseDate', override: { disabled: true } },
  { key: 'DocumentType', override: { disabled: true } },
  'Building',
  'Floor'
],
```
