### PR TITLE
Updates renovate to allow auto-merging of some 'dependencies' and completely disable 'moment-timezone'.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,21 +11,31 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
-      "depTypeList": ["dependencies"],
-      "updateTypes": ["major", "patch"],
-      "enabled": false
-    },
-    {
       "enabled": false,
       "packagePatterns": [
         "^@angular",
         "^angular",
         "angulartics2",
         "directory-encoder",
+        "moment-timezone",
         "ng2-pdf-viewer",
         "pdfjs-dist",
         "axe-webdriverjs",
         "typescript"
+      ]
+    },
+    {
+      "depTypeList": ["dependencies"],
+      "updateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "depTypeList": ["dependencies"],
+      "automerge": true,
+      "packagePatterns": [
+        "lodash",
+        "rxjs",
+        "tslib"
       ]
     },
     {


### PR DESCRIPTION
- Disables 'moment-timezone'. Latest error: https://travis-ci.org/github/uw-it-edm/content-services-ui/jobs/709767594.
- Enables auto-merging of some runtime 'dependendencies': lodash, rxjs and tslib (only for minor and patch updates).