### PR TITLE
CAB-4092: UUI: Delete button not hidden on Document Preview Full Screen Mode

### DIFF
--- a/src/app/content/edit-page/edit-page.component.html
+++ b/src/app/content/edit-page/edit-page.component.html
@@ -44,9 +44,11 @@
             </div>
 
           </div>
-          <div *ngIf="pageConfig?.viewPanel" fxFlex="auto" class="cs-content-view-wrapper">
-            <div class="cs-content-view-wrapper-insert">
-              <app-content-view [contentObject]="contentObject" [allowPageByPageMode]="pageConfig?.allowPageByPageMode"></app-content-view>
+          <div *ngIf="pageConfig?.viewPanel" fxFlex="auto">
+            <div class="cs-content-view-wrapper">
+              <div class="cs-content-view-wrapper-insert">
+                <app-content-view [contentObject]="contentObject" [allowPageByPageMode]="pageConfig?.allowPageByPageMode"></app-content-view>
+              </div>
             </div>
             <div *ngIf="pageConfig?.enableDelete && hasDeletePermission" class="button-row">
               <mat-spinner *ngIf="deletePending" style="margin:0 auto;" aria-label="deletion in progress"></mat-spinner>


### PR DESCRIPTION
This change moves the button to be outside of the "view-wrapper", which keeps it below the preview pane even when in full screen.