### PR TITLE
CAB-4025: UUI: Focus should be on the search box when navigating to Search Page.

### DIFF
--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.html
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.html
@@ -2,7 +2,7 @@
   <div class="cs-content-page">
     <mat-toolbar class="secondary-toolbar" role="navigation">
       <span class="button-row">
-        <button mat-icon-button routerLink="/{{config.tenant}}" [disabled]="isUpdatePending">
+        <button mat-icon-button routerLink="/{{config.tenant}}" [state]="autoFocusNavigationState" [disabled]="isUpdatePending">
           <mat-icon>keyboard_arrow_left</mat-icon>&nbsp;{{areRowsAvailable ? 'Cancel Bulk Update': 'Close Bulk Update'}}
         </button>
       </span>

--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.spec.ts
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.spec.ts
@@ -199,7 +199,7 @@ describe('BulkEditPageComponent', () => {
       fixture.detectChanges();
 
       component.cancel();
-      expect(router.navigate).toHaveBeenCalledWith(['test-tenant']);
+      expect(router.navigate).toHaveBeenCalledWith(['test-tenant'], jasmine.anything());
     });
 
     it('should reset all metadata fields when clicking reset fields button', () => {

--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.ts
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.ts
@@ -14,6 +14,7 @@ import { ContentItem, IContentItem } from '../shared/model/content-item';
 import { ContentService } from '../shared/content.service';
 import { DataService } from '../../shared/providers/data.service';
 import { ContentMetadataComponent } from '../content-metadata/content-metadata.component';
+import { DefaultAutoFocusNavigationState } from '../../shared/shared/auto-focus-navigation-state';
 
 const ROWS_LOCAL_STORAGE_KEY = 'bulk-edit-rows';
 const UPDATE_OPERATION_TIMEOUT = 90 * 1000;
@@ -36,6 +37,13 @@ export class BulkEditPageComponent implements OnInit, OnDestroy {
   contentItem: ContentItem;
 
   @ViewChild(ContentMetadataComponent) contentMetadataComponent: ContentMetadataComponent;
+
+  /**
+   * Getter so that template can bind to the default navigation state.
+   */
+  get autoFocusNavigationState() {
+    return DefaultAutoFocusNavigationState;
+  }
 
   constructor(
     private _router: Router,
@@ -84,7 +92,7 @@ export class BulkEditPageComponent implements OnInit, OnDestroy {
   }
 
   cancel() {
-    this._router.navigate([this.config.tenant]);
+    this._router.navigate([this.config.tenant], { state: DefaultAutoFocusNavigationState });
   }
 
   get areRowsAvailable(): boolean {

--- a/src/app/content/create-page/create-page.component.html
+++ b/src/app/content/create-page/create-page.component.html
@@ -3,7 +3,7 @@
 
     <mat-toolbar class="secondary-toolbar"  >
       <span class="button-row" role="navigation">
-        <button mat-icon-button routerLink="/{{config.tenant}}" matTooltip="Return to Results" aria-label="return to results">
+        <button mat-icon-button routerLink="/{{config.tenant}}" [state]="autoFocusNavigationState" matTooltip="Return to Results" aria-label="return to results">
           <mat-icon>keyboard_arrow_left</mat-icon>
         </button>
       </span>

--- a/src/app/content/create-page/create-page.component.ts
+++ b/src/app/content/create-page/create-page.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  ComponentFactoryResolver,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-  ViewChildren,
-  QueryList,
-} from '@angular/core';
+import { Component, ComponentFactoryResolver, OnDestroy, OnInit, ViewChild, ViewChildren, QueryList } from '@angular/core';
 import { ContentPageConfig } from '../../core/shared/model/content-page-config';
 import { Config } from '../../core/shared/model/config';
 import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
@@ -25,6 +17,7 @@ import { NotificationService } from '../../shared/providers/notification.service
 import { isNullOrUndefined } from '../../core/util/node-utilities';
 import { takeUntil } from 'rxjs/operators';
 import { ComponentCanDeactivateDirective } from '../../routing/shared/component-can-deactivate.directive';
+import { DefaultAutoFocusNavigationState } from '../../shared/shared/auto-focus-navigation-state';
 
 @Component({
   selector: 'app-create-page',
@@ -47,6 +40,13 @@ export class CreatePageComponent extends ComponentCanDeactivateDirective impleme
   @ViewChild(ContentViewComponent, { static: true }) contentViewComponent: ContentViewComponent;
   @ViewChild(ContentObjectListComponent, { static: true }) contentObjectListComponent: ContentObjectListComponent;
   @ViewChildren(FileUploadComponent) fileUploads: QueryList<FileUploadComponent>;
+
+  /**
+   * Getter so that template can bind to the default navigation state.
+   */
+  get autoFocusNavigationState() {
+    return DefaultAutoFocusNavigationState;
+  }
 
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
@@ -99,7 +99,7 @@ export class CreatePageComponent extends ComponentCanDeactivateDirective impleme
   }
 
   cancel() {
-    this.router.navigate([this.config.tenant]);
+    this.router.navigate([this.config.tenant], { state: DefaultAutoFocusNavigationState });
   }
 
   hasError(contentObject: ContentObject): boolean {
@@ -141,7 +141,7 @@ export class CreatePageComponent extends ComponentCanDeactivateDirective impleme
 
   private saveItem(): void {
     this.saveItemInternal().then(() => {
-      this.router.navigate([this.config.tenant]);
+      this.router.navigate([this.config.tenant], { state: DefaultAutoFocusNavigationState });
     });
   }
 

--- a/src/app/content/edit-page/edit-page.component.html
+++ b/src/app/content/edit-page/edit-page.component.html
@@ -2,7 +2,7 @@
   <div class="cs-content-page">
     <mat-toolbar class="secondary-toolbar" role="navigation">
       <span class="button-row">
-        <button mat-icon-button routerLink="/{{config.tenant}}" matTooltip="Return to Results" aria-label="return to results">
+        <button mat-icon-button routerLink="/{{config.tenant}}" [state]="autoFocusNavigationState" matTooltip="Return to Results" aria-label="return to results">
           <mat-icon>keyboard_arrow_left</mat-icon>
         </button>
       </span>

--- a/src/app/content/edit-page/edit-page.component.ts
+++ b/src/app/content/edit-page/edit-page.component.ts
@@ -23,6 +23,7 @@ import { isNullOrUndefined } from '../../core/util/node-utilities';
 import { ComponentCanDeactivateDirective } from '../../routing/shared/component-can-deactivate.directive';
 import { ContentMetadataComponent } from '../content-metadata/content-metadata.component';
 import { FileUploadComponent } from '../../shared/widgets/file-upload/file-upload.component';
+import { DefaultAutoFocusNavigationState } from '../../shared/shared/auto-focus-navigation-state';
 
 @Component({
   selector: 'app-edit-page',
@@ -45,6 +46,13 @@ export class EditPageComponent extends ComponentCanDeactivateDirective implement
   deletePending: boolean; // deletion takes a few seconds
   hasDeletePermission: boolean;
   disableFileReplace: boolean;
+
+  /**
+   * Getter so that template can bind to the default navigation state.
+   */
+  get autoFocusNavigationState() {
+    return DefaultAutoFocusNavigationState;
+  }
 
   @ViewChild(DynamicComponentDirective) contentViewDirective: DynamicComponentDirective;
   @ViewChild(ContentViewComponent) contentViewComponent: ContentViewComponent;
@@ -180,7 +188,7 @@ export class EditPageComponent extends ComponentCanDeactivateDirective implement
             this.form.markAsPristine(); // mark form as pristine after successful deletion
             const message = 'Deleted item ' + this.id;
             alert(message); // snackBar did not work well just before navigating to another page
-            this.router.navigate([this.config.tenant]);
+            this.router.navigate([this.config.tenant], { state: DefaultAutoFocusNavigationState });
           },
           (err) => {
             const message = 'There was an error deleting content item:' + err.statusText;

--- a/src/app/search/search-box/search-box.component.html
+++ b/src/app/search/search-box/search-box.component.html
@@ -4,7 +4,8 @@
       <label for="search-field"
              *ngIf="pageConfig?.searchConfig?.label">{{pageConfig.searchConfig.label}}</label>
       <mat-form-field>
-        <input id="search-field" matInput
+        <input #searchField
+               id="search-field" matInput
                name="search"
                [(ngModel)]="internalSearchField"
                (search)="executeSearch()"

--- a/src/app/search/search-box/search-box.component.ts
+++ b/src/app/search/search-box/search-box.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { SearchModel } from '../shared/model/search-model';
 import { SearchPageConfig } from '../../core/shared/model/search-page-config';
 import { Observable, Subject } from 'rxjs';
@@ -28,6 +28,9 @@ export class SearchBoxComponent implements OnDestroy, OnInit {
   searchAutocomplete: SearchAutocomplete;
   @Input()
   searchModel$: Observable<SearchModel>;
+
+  @ViewChild('searchField')
+  searchInputElement: ElementRef<HTMLInputElement>;
 
   @Input()
   set pageConfig(value: SearchPageConfig) {
@@ -78,6 +81,13 @@ export class SearchBoxComponent implements OnDestroy, OnInit {
 
   private announceFilterSelection(searchFilter: SearchFilter) {
     this.liveAnnouncer.announce('Selected ' + searchFilter.getDisplayValue() + ' filter', 'assertive');
+  }
+
+  /**
+   * Sets the focus on the search box.
+   */
+  focusSearchBox() {
+    this.searchInputElement.nativeElement.focus();
   }
 
   clearSearchBox() {

--- a/src/app/shared/shared/auto-focus-navigation-state.ts
+++ b/src/app/shared/shared/auto-focus-navigation-state.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared navigation state to request target navigation to set its auto-focus.
+ */
+export interface AutoFocusNavigationState {
+  /**
+   * Whether the target of a navigation event should set its auto-focus.
+   */
+  autoFocusOnNavigate: boolean;
+}
+
+/**
+ * Navigation state that request target page to set its auto-focus.
+ */
+export const DefaultAutoFocusNavigationState: AutoFocusNavigationState = {
+  autoFocusOnNavigate: true,
+};


### PR DESCRIPTION
Summary of design:
- There is a shared interface that components can use to request auto-focus behavior to the navigation target.
- Pages that support auto-focus, can read the state and apply focus when requested by the navigation caller.
- SearchPageComponent applies auto-focus by placing it on the search box.
- SearchPageComponent also needs to deal with setting focus when moving out of bulk edit selection.

Not included:
- Unit tests and/or integration tests.