### PR TITLE
CAB-4024: Adds unit and integration tests for auto-focus on search box.

### DIFF
--- a/e2e/browserUtils.ts
+++ b/e2e/browserUtils.ts
@@ -39,7 +39,6 @@ export class BrowserUtils {
    * Waits for a snack bar to show with the given text.
    * @param expectedText expected text to be contained in snack bar message.
    * @param timeoutMilliseconds Timeout in milliseconds to wait for.
-   * @param timeoutMilliseconds Timeout in milliseconds to wait for.
    */
   waitForSnackBarText(expectedText: string, timeoutMilliseconds: number = 5000): promise.Promise<any> {
     const supplierFunc = () => element(by.className('mat-simple-snackbar'));

--- a/e2e/browserUtils.ts
+++ b/e2e/browserUtils.ts
@@ -21,8 +21,24 @@ export class BrowserUtils {
   }
 
   /**
+   * Waits for the browser's active element to be the one with the given id.
+   * @param expectedElementId Expected id of the active element.
+   * @param timeoutMilliseconds Timeout in milliseconds to wait for.
+   */
+  waitForActiveElement(expectedElementId: string, timeoutMilliseconds: number = 5000): promise.Promise<any> {
+    const getActiveElementIdFunc = () => browser.driver.switchTo().activeElement().getAttribute('id');
+
+    return this.waitForFunc(
+      () => getActiveElementIdFunc(),
+      (actualId) => actualId === expectedElementId,
+      timeoutMilliseconds
+    ).then(() => expect(getActiveElementIdFunc()).toBe(expectedElementId));
+  }
+
+  /**
    * Waits for a snack bar to show with the given text.
    * @param expectedText expected text to be contained in snack bar message.
+   * @param timeoutMilliseconds Timeout in milliseconds to wait for.
    * @param timeoutMilliseconds Timeout in milliseconds to wait for.
    */
   waitForSnackBarText(expectedText: string, timeoutMilliseconds: number = 5000): promise.Promise<any> {
@@ -31,12 +47,13 @@ export class BrowserUtils {
     const visiblePromise = browser.wait(
       ExpectedConditions.visibilityOf(supplierFunc()),
       timeoutMilliseconds,
-      `SnackBar was not visible after ${timeoutMilliseconds} ms.`);
+      `SnackBar was not visible after ${timeoutMilliseconds} ms.`
+    );
 
     return visiblePromise.then(() => {
       return this.waitForFunc(
         () => supplierFunc().getText(),
-        text => (text || '').indexOf(expectedText) >= 0,
+        (text) => (text || '').indexOf(expectedText) >= 0,
         timeoutMilliseconds
       ).then(() => expect(supplierFunc().getText()).toContain(expectedText));
     });
@@ -48,8 +65,12 @@ export class BrowserUtils {
    * @param expectedText Expected text.
    * @param timeoutMilliseconds Timeout in milliseconds to wait for.
    */
-  waitForElementText(elementOrSelector: string | ElementFinder, expectedText: string, timeoutMilliseconds: number = 5000): promise.Promise<any>  {
-    const getElementFinder = () => typeof elementOrSelector !== 'string' ? elementOrSelector : element(by.css(elementOrSelector));
+  waitForElementText(
+    elementOrSelector: string | ElementFinder,
+    expectedText: string,
+    timeoutMilliseconds: number = 5000
+  ): promise.Promise<any> {
+    const getElementFinder = () => (typeof elementOrSelector !== 'string' ? elementOrSelector : element(by.css(elementOrSelector)));
     return this.waitForFunc(
       () => getElementFinder().getText(),
       (text) => (text || '').indexOf(expectedText) >= 0,

--- a/e2e/search/search.local-spec.ts
+++ b/e2e/search/search.local-spec.ts
@@ -72,12 +72,32 @@ describe('Search Page', () => {
     app.runAccessibilityChecks();
   });
 
+  it('should auto-focus search box when navigating from edit page', () => {
+    // go to edit page and click the back to results link.
+    const editPage = new EditPage();
+    editPage.navigateTo();
+    editPage.clickReturnToResultsLink();
+
+    // verify the the search box will receive focus.
+    utils.waitForActiveElement('search-field');
+  });
+
   it('should have no accessibility violations after entering bulk edit mode', () => {
     page.toggleBulkUpdateModeButton.click();
     utils.waitForElementText('h2', 'Bulk Update Mode');
 
     const app = new ContentServicesUiPage();
     app.runAccessibilityChecks();
+  });
+
+  it('should auto-focus search box when exiting bulk edit mode', () => {
+    // enter bulk edit mode.
+    page.toggleBulkUpdateModeButton.click();
+    utils.waitForElementText('h2', 'Bulk Update Mode');
+
+    // exit bulk edit mode and verify the search box will receive focus.
+    page.toggleBulkUpdateModeButton.click();
+    utils.waitForActiveElement('search-field');
   });
 
   it('should display page title', () => {

--- a/src/app/content/bulk-edit-page/bulk-edit-page.component.spec.ts
+++ b/src/app/content/bulk-edit-page/bulk-edit-page.component.spec.ts
@@ -199,7 +199,7 @@ describe('BulkEditPageComponent', () => {
       fixture.detectChanges();
 
       component.cancel();
-      expect(router.navigate).toHaveBeenCalledWith(['test-tenant'], jasmine.anything());
+      expect(router.navigate).toHaveBeenCalledWith(['test-tenant'], { state: { autoFocusOnNavigate: true } });
     });
 
     it('should reset all metadata fields when clicking reset fields button', () => {


### PR DESCRIPTION
Test strategy:

Instead of verifying each individual navigation case, the primary goal is to verify that the search page puts focus on the search-box if the right navigation state is supplied by the source of navigation.

Additionally, verify the special case when exiting bulk edit mode the search page puts focus on the search-box.

Navigation sources can be tested via unit tests, and I updated the bulk-edit page unit test to check that the navigation state is passed.