### PR TITLE
Updates chrome on machine before running E2E tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12'
+      - run: |
+          sudo apt-get update
+          sudo apt-get upgrade google-chrome-stable -y
       - run: yarn install
       - run: yarn e2e-local
       - name: Slack Notification


### PR DESCRIPTION
GitHub action updates driver and chrome weekly, if the build updates the driver we need to update chrome. For more details see: https://github.com/actions/virtual-environments/issues/701