### PR TITLE
Removes the azure from apt-get sources list for E2E tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - run: sudo apt-get upgrade google-chrome-stable -y
       - run: yarn install
       - run: yarn e2e-local
       - name: Slack Notification


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/issues/675