### PR TITLE
CAB-4228: Adds a warning message to the UUI header set via config.

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,4 @@
+.header-warning-message {
+  padding: 10px;
+  background-color: lightyellow;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,9 @@
 <app-header>
   <mat-progress-bar [color]="color" [mode]="mode" [value]="value"></mat-progress-bar>
 </app-header>
+<div class="header-warning-message" *ngIf="warningHeaderMessage">
+  {{warningHeaderMessage}}
+</div>
 <section class="mat-typography">
   <router-outlet></router-outlet>
 </section>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,16 +1,18 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed, async, inject } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ProgressService } from './shared/providers/progress.service';
+import { ApplicationStateService } from './shared/providers/application-state.service';
 import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';
+import { By } from '@angular/platform-browser';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [AppComponent],
-      providers: [ProgressService, { provide: Angulartics2GoogleTagManager, useValue: {} }],
-      schemas: [NO_ERRORS_SCHEMA]
+      providers: [ProgressService, ApplicationStateService, { provide: Angulartics2GoogleTagManager, useValue: {} }],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
 
@@ -24,5 +26,22 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('app');
+  }));
+
+  it('should display warning header message when set', inject([ApplicationStateService], (appStateService: ApplicationStateService) => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app: AppComponent = fixture.debugElement.componentInstance;
+    expect(app.title).toEqual('app');
+
+    // Verify that by default the app has no warning message.
+    let headerDiv = fixture.debugElement.query(By.css('.header-warning-message'));
+    expect(headerDiv).toBeNull();
+
+    // Set the warning message and verify that element appears.
+    appStateService.setWarningHeaderMessage('test header message');
+    fixture.detectChanges();
+
+    headerDiv = fixture.debugElement.query(By.css('.header-warning-message'));
+    expect(headerDiv.nativeElement.textContent).toContain('test header message');
   }));
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { ProgressService } from './shared/providers/progress.service';
+import { ApplicationStateService } from './shared/providers/application-state.service';
 import { Angulartics2GoogleTagManager } from 'angulartics2/gtm';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
   title = 'app';
@@ -14,22 +15,29 @@ export class AppComponent {
   mode = 'indeterminate';
   value = 0;
 
+  warningHeaderMessage = '';
+
   constructor(
     private changeDetector: ChangeDetectorRef,
+    private appStateService: ApplicationStateService,
     public progressService: ProgressService,
     angulartics2GoogleTagManager: Angulartics2GoogleTagManager
   ) {
-    progressService.color$.subscribe(color => {
+    progressService.color$.subscribe((color) => {
       this.color = color;
       this.changeDetector.detectChanges();
     });
-    progressService.mode$.subscribe(mode => {
+    progressService.mode$.subscribe((mode) => {
       this.mode = mode;
       this.changeDetector.detectChanges();
     });
-    progressService.value$.subscribe(value => {
+    progressService.value$.subscribe((value) => {
       this.value = value;
       this.changeDetector.detectChanges();
+    });
+
+    appStateService.warningHeaderMessageChanged$.subscribe((message) => {
+      this.warningHeaderMessage = message;
     });
   }
 }

--- a/src/app/core/shared/model/config.ts
+++ b/src/app/core/shared/model/config.ts
@@ -9,6 +9,11 @@ export class Config {
   customText: Map<string, CustomTextItem>;
 
   availableFields: Array<Field>;
+
+  /**
+   * Warning message to show in the header of the application. See CAB-4228 for details.
+   */
+  warningHeaderMessage: string;
 }
 
 export class ContentConfig {

--- a/src/app/routing/shared/config-resolver.service.spec.ts
+++ b/src/app/routing/shared/config-resolver.service.spec.ts
@@ -2,6 +2,7 @@ import { async, inject, TestBed } from '@angular/core/testing';
 
 import { ConfigResolver } from './config-resolver.service';
 import { ConfigService } from '../../core/shared/config.service';
+import { ApplicationStateService } from '../../shared/providers/application-state.service';
 import { Config } from '../../core/shared/model/config';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { Injector } from '@angular/core';
@@ -20,6 +21,7 @@ class MockConfigService {
     if (tenant === 'test-tenant') {
       config = new Config();
       config.tenant = 'test-tenant';
+      config.warningHeaderMessage = 'test warning header message';
     } else {
       config = null;
     }
@@ -28,12 +30,17 @@ class MockConfigService {
 }
 
 describe('ConfigResolverService', () => {
+  let appStateServiceSpy: ApplicationStateService;
+
   beforeEach(async(() => {
     const _mockConfigService = new MockConfigService();
+    appStateServiceSpy = jasmine.createSpyObj('ApplicationStateService', ['setWarningHeaderMessage']);
+
     TestBed.configureTestingModule({
       imports: [MatSnackBarModule],
       providers: [
         ConfigResolver,
+        { provide: ApplicationStateService, useValue: appStateServiceSpy },
         { provide: ConfigService, useValue: _mockConfigService },
         { provide: Router, useClass: RouterStub },
         NotificationService,
@@ -50,14 +57,18 @@ describe('ConfigResolverService', () => {
     expect(configResolverService).toBeTruthy();
   }));
 
-  it('should call config service with the correct tenant', inject([ConfigResolver], (service: ConfigResolver) => {
-    const route = new ActivatedRouteSnapshot();
-    const routeParams = { tenant: 'test-tenant' };
-    route.params = routeParams;
-    service.resolve(route, null).then((config) => {
-      expect(config.tenant).toBe('test-tenant');
-    });
-  }));
+  it('should call config service with the correct tenant and set warning header message', inject(
+    [ConfigResolver],
+    (service: ConfigResolver) => {
+      const route = new ActivatedRouteSnapshot();
+      const routeParams = { tenant: 'test-tenant' };
+      route.params = routeParams;
+      service.resolve(route, null).then((config) => {
+        expect(config.tenant).toBe('test-tenant');
+        expect(appStateServiceSpy.setWarningHeaderMessage).toHaveBeenCalledWith('test warning header message');
+      });
+    }
+  ));
 
   it('should return null if tenant doesnt exist', inject([ConfigResolver], (service: ConfigResolver) => {
     const route = new ActivatedRouteSnapshot();

--- a/src/app/routing/shared/config-resolver.service.ts
+++ b/src/app/routing/shared/config-resolver.service.ts
@@ -4,6 +4,7 @@ import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@a
 import { Config, CustomTextItem } from '../../core/shared/model/config';
 import { Observable, ReplaySubject, Subject } from 'rxjs';
 import { NotificationService } from '../../shared/providers/notification.service';
+import { ApplicationStateService } from '../../shared/providers/application-state.service';
 
 @Injectable()
 export class ConfigResolver implements Resolve<Config> {
@@ -13,7 +14,8 @@ export class ConfigResolver implements Resolve<Config> {
   constructor(
     private configService: ConfigService,
     private router: Router,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private appStateService: ApplicationStateService
   ) {}
 
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<Config> {
@@ -33,11 +35,12 @@ export class ConfigResolver implements Resolve<Config> {
 
     return this.configService
       .getConfigForTenant(tenant)
-      .then(config => {
+      .then((config) => {
         if (config) {
           console.log('returning ' + config);
           this.customText$.next(config.customText);
           this.appName$.next(this.getAppName(config));
+          this.appStateService.setWarningHeaderMessage(config?.warningHeaderMessage);
           return config;
         } else {
           console.log('no config for ' + tenant);
@@ -46,7 +49,7 @@ export class ConfigResolver implements Resolve<Config> {
           return null;
         }
       })
-      .catch(err => {
+      .catch((err) => {
         this.notificationService.error('Cannot load configuration', err);
         this.redirectToHome();
         return null;

--- a/src/app/search/facets-box/facets-box.component.spec.ts
+++ b/src/app/search/facets-box/facets-box.component.spec.ts
@@ -22,7 +22,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 class MockConfigResolver extends ConfigResolver {
   constructor() {
-    super(null, null, null);
+    super(null, null, null, null);
   }
 
   getCustomTextSubject(): Observable<Map<string, CustomTextItem>> {
@@ -53,9 +53,9 @@ describe('FacetsBoxComponent', () => {
       providers: [
         { provide: ConfigResolver, useValue: new MockConfigResolver() },
         { provide: DataApiValueService, useValue: new MockDataApiValueService() },
-        { provide: NotificationService, useValue: new MockNotificationService() }
+        { provide: NotificationService, useValue: new MockNotificationService() },
       ],
-      schemas: [NO_ERRORS_SCHEMA]
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
 

--- a/src/app/shared/providers/application-state.service.ts
+++ b/src/app/shared/providers/application-state.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * Service that exposes events to change the general state of the application.
+ */
+@Injectable()
+export class ApplicationStateService {
+  private warningHeaderMessageSource = new Subject<string>();
+
+  warningHeaderMessageChanged$ = this.warningHeaderMessageSource.asObservable();
+
+  /**
+   * Sets the header warning message. See CAB-4228 for details.
+   * @param message Message to set in the header (note: HTML will be escaped).
+   */
+  setWarningHeaderMessage(message: string) {
+    this.warningHeaderMessageSource.next(message);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -19,6 +19,7 @@ import { TimestampPickerComponent } from './widgets/timestamp-picker/timestamp-p
 import { TruncatePipe } from './pipes/truncate.pipe';
 import { DisplayFieldComponent } from './widgets/display-field/display-field.component';
 import { ProgressService } from './providers/progress.service';
+import { ApplicationStateService } from './providers/application-state.service';
 import { FocusDirective } from './directives/focus/focus.directive';
 import { OptionsInputComponent } from './widgets/options-input/options-input.component';
 import { OptionsAutocompleteComponent } from './widgets/options-autocomplete/options-autocomplete.component';
@@ -94,7 +95,16 @@ import { A11yModule } from '@angular/cdk/a11y';
     CourseInputComponent,
     ElasticsearchDateValidatorDirective,
   ],
-  providers: [DataService, FieldOptionService, ProgressService, StudentService, PersonService, DataApiValueService, NotificationService],
+  providers: [
+    DataService,
+    FieldOptionService,
+    ProgressService,
+    ApplicationStateService,
+    StudentService,
+    PersonService,
+    DataApiValueService,
+    NotificationService,
+  ],
   entryComponents: [NotificationComponent],
 })
 export class SharedModule {}

--- a/src/app/shared/widgets/header/header.component.spec.ts
+++ b/src/app/shared/widgets/header/header.component.spec.ts
@@ -15,6 +15,7 @@ import { ProgressService } from '../../providers/progress.service';
 import { NotificationService } from '../../providers/notification.service';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { User } from '../../../user/shared/user';
+import { ApplicationStateService } from './../../providers/application-state.service';
 
 class RouterStub {
   navigate(url: string) {
@@ -57,11 +58,12 @@ describe('HeaderComponent', () => {
         { provide: ConfigService, useValue: configServiceStub },
         { provide: UserService, useValue: new MockUserService() },
         ConfigResolver,
+        ApplicationStateService,
         GlobalEventsManagerService,
         ProgressService,
-        NotificationService
+        NotificationService,
       ],
-      schemas: [NO_ERRORS_SCHEMA]
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
 
@@ -80,7 +82,7 @@ describe('HeaderComponent', () => {
     const routeParams = { tenant: 'test-tenant' };
     route.params = routeParams;
     inject([ConfigResolver], (service: ConfigResolver) => {
-      service.resolve(route, null).then(config => {
+      service.resolve(route, null).then((config) => {
         expect(component.accountMenu.items.length).toBeGreaterThanOrEqual(4);
       });
     });


### PR DESCRIPTION
Summary:
This change follows the pattern described [here](https://angular.io/guide/component-interaction#parent-and-children-communicate-via-a-service) and adds a mechanism for components to communicate changes in state to the main app component. One of these states is the warning header message.

Notes:
- As always, the commit hook that runs 'prettier' re-formatted other lines in the files touched that are outside the scope of this change.