### PR TITLE
CAB-4325: Restricts input to number and adds $ prefix for displayType=currency fields.

### DIFF
--- a/e2e/mocks/content-api/item.json
+++ b/e2e/mocks/content-api/item.json
@@ -26,6 +26,7 @@
     "DataApiOptionCode": "VAL_1",
     "DataApiWithFilter": "VAL_1",
     "DataApiOptionMultiSelect": ["VAL_1", "VAL_3"],
-    "courses": "2019|autumn|PHYS|101|GROUP SCI INQUIRY I|B"
+    "courses": "2019|autumn|PHYS|101|GROUP SCI INQUIRY I|B",
+    "InvoiceAmount": "1220.30"
   }
 }

--- a/e2e/mocks/profile-api/demo6-currency.json
+++ b/e2e/mocks/profile-api/demo6-currency.json
@@ -1,0 +1,71 @@
+{
+  "account": "demo-account",
+  "tenant": "demo6-currency",
+  "appName": "Demo 6: Currency",
+  "availableFields": [
+    {
+      "key": "InvoiceAmount",
+      "label": "Invoice Amount",
+      "dataType": "number",
+      "displayType": "currency"
+    },
+    {
+      "key": "Filer",
+      "label": "Filer"
+    }
+  ],
+  "pages": {
+    "tab-search": {
+      "pageName": "Demonstration Search",
+      "theme": "uw-default",
+      "searchConfig": {
+        "directions": "Type a Employee ID or other info",
+        "label": "",
+        "placeholder": "Search for documents",
+        "indexName": "documents-demo3"
+      },
+      "fieldReferencesToDisplay": [
+        "Filer",
+        "InvoiceAmount"
+      ]
+    },
+    "edit": {
+      "theme": "uw-default",
+      "pageName": "Edit Content Item",
+      "fieldKeysToDisplay": [
+        "Filer",
+        "InvoiceAmount"
+      ],
+      "buttons": [
+        {
+          "label": "Save",
+          "color": "primary",
+          "command": "saveItem"
+        }
+      ],
+      "viewPanel": true,
+      "disableFileReplace": true
+    },
+    "create": {
+      "theme": "uw-default",
+      "pageName": "Create Content Item",
+      "fieldReferencesToDisplay": [
+        "Filer",
+        "InvoiceAmount"
+      ],
+      "buttons": [
+        {
+          "label": "Save",
+          "color": "primary",
+          "command": "saveItem"
+        },
+        {
+          "label": "Cancel",
+          "alwaysActive": true,
+          "command": "cancel"
+        }
+      ],
+      "viewPanel": true
+    }
+  }
+}

--- a/e2e/mocks/profile-api/list.json
+++ b/e2e/mocks/profile-api/list.json
@@ -14,6 +14,9 @@
     },
     "demo5-legalnames": {
       "href": "http://__current_host__:12345/profile/v1/app/my-app/demo5"
+    },
+    "demo6-currency": {
+      "href": "http://__current_host__:12345/profile/v1/app/my-app/demo6-currency"
     }
   }
 }

--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -108,7 +108,9 @@
                      [placeholder]="fieldToDisplay.label"
                      [attr.aria-label]="fieldToDisplay.label"
                      [required]="fieldHasRequiredError(fieldToDisplay)"
+                     [type]="fieldToDisplay.displayType === 'currency' ? 'number': 'text'"
               >
+              <span matPrefix *ngIf="fieldToDisplay.displayType === 'currency'">$&nbsp;</span>
               <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
               <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
           </mat-form-field>

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -32,6 +32,7 @@ import { DataApiValueService } from '../../shared/providers/dataapivalue.service
 import { FieldOptionService } from '../../shared/providers/fieldoption.service';
 import { PersonAutocompleteComponent } from '../../shared/widgets/person-autocomplete/person-autocomplete.component';
 import { CustomTextDirective } from '../../shared/directives/custom-text/custom-text.directive';
+import { By } from '@angular/platform-browser';
 
 function getContentItem(): ContentItem {
   const contentItem = new ContentItem();
@@ -44,6 +45,7 @@ function getContentItem(): ContentItem {
   contentItem.metadata['b'] = 'asdf';
   contentItem.metadata['parentKey'] = 'parent1';
   contentItem.metadata['d'] = 1509519600000;
+  contentItem.metadata['n'] = 1220.3;
   return contentItem;
 }
 
@@ -63,6 +65,7 @@ function getPageConfig({ addCascadingSelects }: { addCascadingSelects?: boolean 
       displayType: 'select',
       options: [new FieldOption('parent1'), new FieldOption('parent2')],
     }),
+    Object.assign(new Field(), { key: 'n', label: 'number', displayType: 'currency' }),
   ];
 
   if (addCascadingSelects) {
@@ -202,7 +205,16 @@ describe('ContentMetadataComponent', () => {
       a: 'a',
       parentKey: 'parent1',
       d: 1509519600000,
+      n: 1220.3,
     });
+  });
+
+  it('should set input type to number and add $ prefix if displayType=currency', () => {
+    const inputElement = fixture.debugElement.query(By.css('input[name=n]'));
+    expect(inputElement.nativeElement.type).toBe('number');
+
+    const prefixElement = fixture.debugElement.query(By.css('.mat-form-field-prefix'));
+    expect(prefixElement.nativeElement.textContent).toContain('$');
   });
 
   describe('built in validators', () => {


### PR DESCRIPTION
input type="number" rejects non-numerical entries. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number.

A "$" prefix is also added to make it clear to user that the field represents a currency amount. See screen shot below.