### PR TITLE
CAB-4325: Adds regex validator for number fields.

### DIFF
--- a/src/app/content/content-metadata/content-metadata.component.html
+++ b/src/app/content/content-metadata/content-metadata.component.html
@@ -8,7 +8,7 @@
             [placeholder]="fieldToDisplay.label"
             [fieldConfig]="fieldToDisplay"
             [parentControl]="formGroup.get('metadata').get(fieldToDisplay.dynamicSelectConfig?.parentFieldConfig?.key || '')"
-            [errorMessage]="getErrorMessage(fieldToDisplay.key)"
+            [errorMessage]="getErrorMessage(fieldToDisplay)"
             [required]="fieldHasRequiredError(fieldToDisplay)"
             [id]="'custom-input-'+ i"
             [attr.id]="'custom-input-'+ i">
@@ -18,7 +18,7 @@
             [placeholder]="fieldToDisplay.label"
             [fieldConfig]="fieldToDisplay"
             [parentControl]="formGroup.get('metadata').get(fieldToDisplay.dynamicSelectConfig?.parentFieldConfig?.key || '')"
-            [errorMessage]="getErrorMessage(fieldToDisplay.key)"
+            [errorMessage]="getErrorMessage(fieldToDisplay)"
             [required]="fieldHasRequiredError(fieldToDisplay)"
             [id]="'custom-input-'+ i"
             [attr.id]="'custom-input-'+ i">
@@ -36,14 +36,14 @@
             </app-options-input>
             <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
             <mat-error>
-              {{getErrorMessage(fieldToDisplay.key)}}
+              {{getErrorMessage(fieldToDisplay)}}
             </mat-error>
           </mat-form-field>
           <app-timestamp-picker *ngSwitchCase="'date'"
                                 [formControlName]="fieldToDisplay.key"
                                 [placeholder]="fieldToDisplay.label"
                                 [required]="fieldHasRequiredError(fieldToDisplay)"
-                                [errorMessage]="getErrorMessage(fieldToDisplay.key)"
+                                [errorMessage]="getErrorMessage(fieldToDisplay)"
                                 appElasticSearchDateValidator
           >
           </app-timestamp-picker>
@@ -58,7 +58,7 @@
               [attr.id]="'custom-input-'+ i"
             ></app-checkbox-input>
             <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
-            <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
+            <mat-error> {{getErrorMessage(fieldToDisplay)}}</mat-error>
           </mat-form-field>
 
           <mat-form-field *ngSwitchCase="'student-autocomplete'">
@@ -108,11 +108,10 @@
                      [placeholder]="fieldToDisplay.label"
                      [attr.aria-label]="fieldToDisplay.label"
                      [required]="fieldHasRequiredError(fieldToDisplay)"
-                     [type]="fieldToDisplay.displayType === 'currency' ? 'number': 'text'"
               >
               <span matPrefix *ngIf="fieldToDisplay.displayType === 'currency'">$&nbsp;</span>
               <mat-icon *ngIf="fieldToDisplay.disabled" matSuffix class="disabled-icon" matTooltip="Read-only">lock</mat-icon>
-              <mat-error> {{getErrorMessage(fieldToDisplay.key)}}</mat-error>
+              <mat-error> {{getErrorMessage(fieldToDisplay)}}</mat-error>
           </mat-form-field>
         </div>
       </li>

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -252,6 +252,11 @@ describe('ContentMetadataComponent', () => {
       fixture.detectChanges();
       expect(control.valid).toBeFalse();
 
+      // test invalid multiple decimal separators
+      control.setValue('12.34.22');
+      fixture.detectChanges();
+      expect(control.valid).toBeFalse();
+
       // test invalid decimal remainder
       control.setValue('12.');
       control.markAllAsTouched(); // Mark as touched for the error message to show.

--- a/src/app/content/content-metadata/content-metadata.component.spec.ts
+++ b/src/app/content/content-metadata/content-metadata.component.spec.ts
@@ -3,7 +3,7 @@ import { of } from 'rxjs';
 
 import { ContentMetadataComponent } from './content-metadata.component';
 import { ContentItem } from '../shared/model/content-item';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -65,7 +65,7 @@ function getPageConfig({ addCascadingSelects }: { addCascadingSelects?: boolean 
       displayType: 'select',
       options: [new FieldOption('parent1'), new FieldOption('parent2')],
     }),
-    Object.assign(new Field(), { key: 'n', label: 'number', displayType: 'currency' }),
+    Object.assign(new Field(), { key: 'n', label: 'number', displayType: 'currency', dataType: 'number' }),
   ];
 
   if (addCascadingSelects) {
@@ -209,10 +209,7 @@ describe('ContentMetadataComponent', () => {
     });
   });
 
-  it('should set input type to number and add $ prefix if displayType=currency', () => {
-    const inputElement = fixture.debugElement.query(By.css('input[name=n]'));
-    expect(inputElement.nativeElement.type).toBe('number');
-
+  it('should add $ prefix if displayType=currency', () => {
     const prefixElement = fixture.debugElement.query(By.css('.mat-form-field-prefix'));
     expect(prefixElement.nativeElement.textContent).toContain('$');
   });
@@ -224,6 +221,45 @@ describe('ContentMetadataComponent', () => {
       component = fixture.componentInstance;
       component.pageConfig = getPageConfig({ addCascadingSelects: true });
       component.formGroup = new FormGroup({});
+    });
+
+    it('should mark number field as invalid if it fails number validation', () => {
+      fixture.detectChanges();
+      const control: FormControl = component.formGroup.get('metadata').get('n') as FormControl;
+
+      // test valid number
+      control.setValue('1234');
+      fixture.detectChanges();
+      expect(control.valid).toBeTrue();
+
+      // test invalid number
+      control.setValue('words');
+      fixture.detectChanges();
+      expect(control.valid).toBeFalse();
+
+      // test valid large decimal
+      control.setValue('12.34324');
+      fixture.detectChanges();
+      expect(control.valid).toBeTrue();
+
+      // test valid short decimal
+      control.setValue('12.1');
+      fixture.detectChanges();
+      expect(control.valid).toBeTrue();
+
+      // test invalid decimal separator
+      control.setValue('12a34');
+      fixture.detectChanges();
+      expect(control.valid).toBeFalse();
+
+      // test invalid decimal remainder
+      control.setValue('12.');
+      control.markAllAsTouched(); // Mark as touched for the error message to show.
+      fixture.detectChanges();
+      expect(control.valid).toBeFalse();
+
+      const errorElement = fixture.debugElement.query(By.css('.mat-error'));
+      expect(errorElement.nativeElement.textContent).toContain('You must enter a valid number (only digits and optional decimal point).');
     });
 
     it('should mark form as invalid when no fields are set if the empty form validator is enabled', () => {

--- a/src/app/content/content-metadata/content-metadata.component.ts
+++ b/src/app/content/content-metadata/content-metadata.component.ts
@@ -22,6 +22,8 @@ const nonEmptyFormValidator: ValidatorFn = (theForm: FormGroup): ValidationError
   return null;
 };
 
+const NUMBER_REGEX_PATTERN = '^[0-9]+(\\.[0-9]+)?$';
+
 @Component({
   selector: 'app-content-metadata',
   templateUrl: './content-metadata.component.html',
@@ -64,8 +66,18 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy, A
 
   private addValidation(field: Field, formControl: FormControl) {
     // this is where we should handle different type of validation
+
+    const validators: ValidatorFn[] = [];
     if (field.required) {
-      formControl.setValidators(Validators.required);
+      validators.push(Validators.required);
+    }
+
+    if (field.dataType === 'number') {
+      validators.push(Validators.pattern(NUMBER_REGEX_PATTERN));
+    }
+
+    if (validators.length > 0) {
+      formControl.setValidators(validators);
     }
   }
 
@@ -89,9 +101,14 @@ export class ContentMetadataComponent implements OnInit, OnChanges, OnDestroy, A
     this.componentDestroyed.complete();
   }
 
-  getErrorMessage(formControlName: string) {
+  getErrorMessage(field: Field) {
     // this should probably be improved to handle different error type
     // return this.formGroup.controls['metadata'].controls[formControlName].hasError('required') ? 'You must enter a value' : '';
+
+    if (field.dataType === 'number') {
+      return 'You must enter a valid number (only digits and optional decimal point).';
+    }
+
     return 'You must enter a value';
   }
 


### PR DESCRIPTION
Testing revealed that input with type="number" doesn't work well in all browsers. Switched the solution to use a regex validator instead. See screen shot below for experience.